### PR TITLE
Add description into search field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add `description` of the product to search query.
 
 ## [0.3.0] - 2019-01-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.1] - 2019-02-05
 ### Changed
 - Add `description` of the product to search query.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-resources",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "title": "VTEX Store Resources",
   "description": "Common VTEX Store Resources",
   "builders": {

--- a/react/queries/search.gql
+++ b/react/queries/search.gql
@@ -50,6 +50,7 @@ query search($query: String, $map: String, $rest: String, $orderBy: String, $pri
       cacheId
       categories
       productId
+      description
       productName
       linkText
       brand


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add description into search field. This PR is related directly to this [one](https://github.com/vtex-apps/product-summary/pull/110).
<!--- Describe your changes in detail. -->

#### What problem is this solving?
The crash when the product summary is displaying a description of the product in the Search page.
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[Workspace](https://productsummarydescription--storecomponents.myvtex.com/)

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
