### PR TITLE
Add new product search v2 query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.10.0] - 2019-05-01
 ### Added
 - New `productSearchV2` query.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `productSearchV2` query.
 
 ## [0.9.0] - 2019-04-26
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-resources",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "title": "VTEX Store Resources",
   "description": "Common VTEX Store Resources",
   "builders": {

--- a/react/Queries.js
+++ b/react/Queries.js
@@ -4,12 +4,14 @@ import productPreviewFragment from './queries/productPreview.gql'
 import recommendationsAndBenefits from './queries/recommendationsAndBenefits.gql'
 import search from './queries/search.gql'
 import productSearch from './queries/productSearch.gql'
+import productSearchV2 from './queries/productSearchV2.gql'
 import session from './queries/session.gql'
 
 export default {
   orderForm,
   product,
   productSearch,
+  productSearchV2,
   productPreviewFragment,
   recommendationsAndBenefits,
   search,

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -1,0 +1,178 @@
+query search(
+  $query: String,
+  $map: String,
+  $facetQuery: String,
+  $facetMap: String,
+  $orderBy: String,
+  $priceRange: String,
+  $from: Int,
+  $to: Int,
+  $withFacets: Boolean = true
+) {
+  productSearch(query: $query, map: $map, orderBy: $orderBy, priceRange: $priceRange, from: $from, to: $to) {
+    products {
+      cacheId
+      categories
+      productId
+      description
+      productName
+      linkText
+      brand
+      link
+      items {
+        itemId
+        name
+        nameComplete
+        complementName
+        ean
+        referenceId {
+          Key
+          Value
+        }
+        measurementUnit
+        unitMultiplier
+        images {
+          cacheId
+          imageId
+          imageLabel
+          imageTag
+          imageUrl
+          imageText
+        }
+        sellers {
+          sellerId
+          sellerName
+          commertialOffer {
+            discountHighlights {
+              name
+            }
+            Price
+            ListPrice
+            PriceWithoutDiscount
+            RewardValue
+            PriceValidUntil
+            AvailableQuantity
+          }
+        }
+      }
+      productClusters {
+        name
+      }
+    }
+    recordsFiltered
+  }
+  facets(query: $facetQuery, map: $facetMap) @include (if: $withFacets) {
+    departments {
+      quantity
+      name
+      link
+      linkEncoded
+      map
+      selected
+      value
+    }
+    brands {
+      quantity
+      name
+      link
+      linkEncoded
+      map
+      selected
+      value
+    }
+    specificationFilters {
+      name
+      facets {
+        quantity
+        name
+        link
+        linkEncoded
+        map
+        selected
+        value
+      }
+    }
+    categoriesTrees {
+      id
+      quantity
+      name
+      link
+      linkEncoded
+      map
+      selected
+      value
+      children {
+        id
+        quantity
+        name
+        link
+        linkEncoded
+        map
+        selected
+        value
+        children {
+          id
+          quantity
+          name
+          link
+          linkEncoded
+          map
+          selected
+          value
+        }
+      }
+    }
+    priceRanges {
+      quantity
+      name
+      link
+      linkEncoded
+      slug
+      map
+    }
+    recordsFiltered
+    # Backwards compatibility with search-result v3
+    Departments {
+      Quantity
+      Name
+      Link
+    }
+    Brands {
+      Quantity
+      Name
+      Link
+    }
+    SpecificationFilters {
+      name
+      facets {
+        Quantity
+        Name
+        Link
+      }
+    }
+    CategoriesTrees {
+      Id
+      Quantity
+      Name
+      Link
+      Children {
+        Id
+        Quantity
+        Name
+        Link
+        Children {
+          Id
+          Quantity
+          Name
+          Link
+        }
+      }
+    }
+    PriceRanges {
+      Quantity
+      Name
+      Link
+      Slug
+    }
+  }
+}

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -1,15 +1,24 @@
 query search(
-  $query: String,
-  $map: String,
-  $facetQuery: String,
-  $facetMap: String,
-  $orderBy: String,
-  $priceRange: String,
-  $from: Int,
-  $to: Int,
+  $query: String
+  $map: String
+  $facetQuery: String
+  $facetMap: String
+  $orderBy: String
+  $priceRange: String
+  $from: Int
+  $to: Int
   $withFacets: Boolean = true
 ) {
-  productSearch(query: $query, map: $map, orderBy: $orderBy, priceRange: $priceRange, from: $from, to: $to) {
+  productSearch(
+    query: $query
+    map: $map
+    orderBy: $orderBy
+    priceRange: $priceRange
+    from: $from
+    to: $to
+  ) {
+    titleTag
+    metaTagDescription
     products {
       cacheId
       categories
@@ -61,7 +70,7 @@ query search(
     }
     recordsFiltered
   }
-  facets(query: $facetQuery, map: $facetMap) @include (if: $withFacets) {
+  facets(query: $facetQuery, map: $facetMap) @include(if: $withFacets) {
     departments {
       quantity
       name


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a new `productSearchV2` query, to use the `productSearch` of the store-grapqhl.

#### What problem is this solving?
The information about the recordsFiltered was inside the `Facets` type, and it should be in the response of the products too.

The new file added is for backwards compatibility, so the version of the store and search-result using the `productSearch` don't break out of nowhere, because the expected types aren't paired up. The only difference between the V2 and the old one is the name of the query (`products` vs `productSearch`) and that the returned value has a `products` property with all properties of the other query, and a **new** `recordsFiltered` property.

#### How should this be manually tested?
[workspace](https://lucas--storecomponents.myvtex.com/shoes).

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
