### PR TITLE
Add the usePWA hook (and the PWAContext)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `PWAContext` and `usePWA` to allow apps to control, for now, the install prompt (Add to Home Screen).
 
 ## [0.11.1] - 2019-05-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.12.0] - 2019-05-10
 ### Added
 - `PWAContext` and `usePWA` to allow apps to control, for now, the install prompt (Add to Home Screen).
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-resources",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "title": "VTEX Store Resources",
   "description": "Common VTEX Store Resources",
   "builders": {

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -19,7 +19,7 @@ const PWAProvider = ({ settings, children }) => {
       if (promptOnCustomEvent && !captured.current) {
         e.preventDefault()
         deferredPrompt.current = e
-        captured.current = false
+        captured.current = true
         return false
       }
       return true

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -4,19 +4,22 @@ import React, {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react'
 
 const PWAContext = React.createContext(null)
 
 const PWAProvider = ({ settings, children }) => {
   const deferredPrompt = useRef(null)
+  /* beforeinstallprompt event is fired even after the userChoice is to cancel */
+  const [captured, setCaptured] = useState(false)
   useEffect(() => {
     const handleBeforeInstall = e => {
-      console.log('handleBeforeInstall', settings)
       const { promptOnCustomEvent } = settings
-      if (promptOnCustomEvent) {
+      if (promptOnCustomEvent && !captured) {
         e.preventDefault()
         deferredPrompt.current = e
+        setCaptured(true)
         return false
       }
       return true
@@ -25,7 +28,7 @@ const PWAProvider = ({ settings, children }) => {
     window.addEventListener('beforeinstallprompt', handleBeforeInstall)
     return () =>
       window.removeEventListener('beforeinstallprompt', handleBeforeInstall)
-  }, [settings])
+  }, [captured, settings])
 
   const showInstallPrompt = useCallback(() => {
     const prompt = deferredPrompt.current

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -4,22 +4,22 @@ import React, {
   useEffect,
   useMemo,
   useRef,
-  useState,
 } from 'react'
 
 const PWAContext = React.createContext(null)
 
 const PWAProvider = ({ settings, children }) => {
   const deferredPrompt = useRef(null)
-  /* beforeinstallprompt event is fired even after the userChoice is to cancel */
-  const [captured, setCaptured] = useState(false)
+  /* beforeinstallprompt event is fired even after the userChoice is to cancel (and there is no need to re-render) */
+  const captured = useRef(false)
+
   useEffect(() => {
     const handleBeforeInstall = e => {
       const { promptOnCustomEvent } = settings
-      if (promptOnCustomEvent && !captured) {
+      if (promptOnCustomEvent && !captured.current) {
         e.preventDefault()
         deferredPrompt.current = e
-        setCaptured(true)
+        captured.current = false
         return false
       }
       return true

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -1,0 +1,49 @@
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
+
+const PWAContext = React.createContext(null)
+
+const PWAProvider = ({ settings, children }) => {
+  const deferredPrompt = useRef(null)
+  useEffect(() => {
+    const handleBeforeInstall = e => {
+      console.log('handleBeforeInstall', settings)
+      const { promptOnCustomEvent } = settings
+      if (promptOnCustomEvent) {
+        e.preventDefault()
+        deferredPrompt.current = e
+        return false
+      }
+      return true
+    }
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstall)
+    return () =>
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstall)
+  }, [settings])
+
+  const showInstallPrompt = useCallback(() => {
+    const prompt = deferredPrompt.current
+    if (prompt) {
+      prompt.prompt()
+      prompt.userChoice.finally(result => {
+        deferredPrompt.current = null
+      })
+    }
+  }, [])
+
+  const context = useMemo(() => ({ showInstallPrompt }), [showInstallPrompt])
+
+  return <PWAContext.Provider value={context}>{children}</PWAContext.Provider>
+}
+
+const usePWA = () => {
+  return useContext(PWAContext)
+}
+
+export default { PWAContext, PWAProvider, usePWA }


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, a new context was created.

#### What problem is this solving?

An elegant way of allowing apps to show the PWA installation prompt (without having to `window.postMessage`)

#### How should this be manually tested?

[Workspace](https://prompt--storecomponents.myvtex.com/admin/cms/storefront). Cancel the mini info-bar and click the buy button.

#### Screenshots or example usage

![Screenshot_20190510-142335](https://user-images.githubusercontent.com/15948386/57545086-a3c89700-732f-11e9-81a4-e1fc894f1f82.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
