### PR TITLE
Add productReference to product.gql

### DIFF
--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -7,6 +7,7 @@ query Product($slug: String) {
     titleTag
     metaTagDescription
     linkText
+    productReference
     categories
     categoryId
     categoriesIds


### PR DESCRIPTION
#### What is the purpose of this pull request?

Return productReference attribute in the query

#### What problem is this solving?

Allow use productReference in default vtex query

#### How should this be manually tested?

We can add productReference to editor graphql IDE in product query

#### Screenshots or example usage

https://drive.google.com/file/d/1hOPGK1j6Lf2JCpSTgm_crJutyatJ3khQ/view?usp=sharing

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ x ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
