### PR TITLE
Return installments on search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Return `Installments` for `search-result`.
 
 ## [0.14.3] - 2019-06-27
 

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -62,6 +62,13 @@ query search(
             discountHighlights {
               name
             }
+            Installments {
+              Value
+              InterestRate
+              TotalValuePlusInterestRate
+              NumberOfInstallments
+              Name
+            }
             Price
             ListPrice
             PriceWithoutDiscount


### PR DESCRIPTION
#### What is the purpose of this pull request?
Return installments in search-result

#### What problem is this solving?
Even when sending 'showInstallments' on product-summary, the installments don't appear.

#### Screenshots or example usage
![Screen Shot 2019-06-28 at 13 49 29](https://user-images.githubusercontent.com/3163867/60358036-959c0c00-99ab-11e9-930a-a450cfa41f78.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
