### PR TITLE
Feature/discounts and teasers fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `Teasers` and `Discount` field in `Product` and `ProductSearchV2` queries.
 
 ## [0.14.2] - 2019-06-24
 ### Added

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -57,6 +57,9 @@ query Product($slug: String) {
           discountHighlights {
             name
           }
+          teasers {
+            name
+          }
           Price
           ListPrice
           PriceWithoutDiscount

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -62,6 +62,9 @@ query search(
             discountHighlights {
               name
             }
+            teasers {
+              name
+            }
             Price
             ListPrice
             PriceWithoutDiscount


### PR DESCRIPTION
#### What is the purpose of this pull request?

Get DiscountHighlights and Teasers in ProductSearch and Product queries

#### How should this be manually tested?
Account: prueba1 Workspace: vtexexito

In the props of the ProductSummary check if the fields Teasers and DiscountHighlights are comming in the product property.

[ProductDetails Test](https://vtexexito--prueba1.myvtex.com/nevera-no-frost-370-lt-pl-463797/p)

[SearchResult Test](https://vtexexito--prueba1.myvtex.com/nevera)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/20094423/60686377-ffb22680-9e6d-11e9-8b8e-8abaa1cac112.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
