### PR TITLE
Add properties field in SearchProductsV2 query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `properties` field in `ProductSearchV2` query.
 
 ## [0.15.1] - 2019-07-04
 ### Added

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -85,6 +85,10 @@ query search(
         id
         name
       }
+      properties {
+        name
+        values
+      }
     }
     recordsFiltered
     breadcrumb {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Get the Product Properties in the SearchResult pages.

#### How should this be manually tested?
It should show the properties field in the Product.

[GraphiQL](https://vtexexito--prueba1.myvtex.com/_v/vtex.store-resources@0.15.1/graphiql/v1?operationName=search&variables=%7B%0A%20%20%22withFacets%22%3A%20true%2C%0A%20%20%22query%22%3A%20%22textil%22%2C%0A%20%20%22map%22%3A%20%22c%22%2C%0A%20%20%22orderBy%22%3A%20%22OrderByTopSaleDESC%22%2C%0A%20%20%22from%22%3A%200%2C%0A%20%20%22to%22%3A%209%2C%0A%20%20%22facetQuery%22%3A%20%22textil%22%2C%0A%20%20%22facetMap%22%3A%20%22c%22%0A%7D
)

[Query](https://paste.ofcode.org/yDRrD9VBgiLvQzk9vDp3iP) (Too long)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/20094423/61000597-67131f00-a323-11e9-84b1-d046f5f0922d.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
