### PR TITLE
Add customData in OrderFormContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `customData` field in `OrderForm` query.
 
 ## [0.16.0] - 2019-07-10
 ### Added

--- a/react/OrderFormContext.js
+++ b/react/OrderFormContext.js
@@ -61,6 +61,16 @@ const contextPropTypes = PropTypes.shape({
     /* Items in the mini cart */
 
     items: PropTypes.arrayOf(PropTypes.object),
+    /* CustomData in the OrderForm */
+
+    customData: PropTypes.shape({
+      customApps: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.string,
+          fields: PropTypes.object
+        })
+      )
+    }),
     /* Shipping Address */
 
     shippingData: PropTypes.shape({

--- a/react/queries/orderForm.gql
+++ b/react/queries/orderForm.gql
@@ -2,6 +2,12 @@ query orderForm {
   orderForm {
     cacheId
     orderFormId
+    customData {
+      customApps {
+        id
+        fields
+      }
+    }
     value
     totalizers {
       id


### PR DESCRIPTION
#### What is the purpose of this pull request?

To avoid send multiple mutations setOrderFormCustomData, we update the query fields of orderForm and the PropTypes of OrderFormContext to support this functionality.

#### What problem is this solving?

With the `customData` we can improve applications that use these queries.

#### How should this be manually tested?

1. Go to the page: https://orderform--tokstoklista.myvtex.com/casamento/guyas;
1. Open DevTools;
1. Open the Minicart file (./react/components/minicart/Minicart.js);
1. Add a breakpoint in line 122;
1. Scroll down the page and add a product to cart;
1. Debug.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/1207017/61487452-4fb7df80-a97c-11e9-864c-1d104d24a136.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
