### PR TITLE
Add new fields to cart related queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Fields `productRefId`, `additionalInfo`, `productCategoryIds`, `productCategories` to cart related queries: `orderForm`, `addToCart` and `updateItems`.
 
 ## [0.17.0] - 2019-07-18
 ### Added

--- a/react/mutations/addToCart.gql
+++ b/react/mutations/addToCart.gql
@@ -13,6 +13,12 @@ mutation addItem($orderFormId: String, $items: [OrderFormItemInput]) {
       name
       imageUrl
       detailUrl
+      productRefId
+      additionalInfo {
+        brandName
+      }
+      productCategoryIds
+      productCategories
       skuName
       quantity
       sellingPrice

--- a/react/mutations/updateItems.gql
+++ b/react/mutations/updateItems.gql
@@ -13,6 +13,12 @@ mutation updateItems($orderFormId: String, $items: [OrderFormItemInput]) {
       name
       imageUrl
       detailUrl
+      productRefId
+      additionalInfo {
+        brandName
+      }
+      productCategoryIds
+      productCategories
       skuName
       quantity
       sellingPrice

--- a/react/queries/orderForm.gql
+++ b/react/queries/orderForm.gql
@@ -19,6 +19,12 @@ query orderForm {
       name
       imageUrl
       detailUrl
+      productRefId
+      additionalInfo {
+        brandName
+      }
+      productCategoryIds
+      productCategories
       skuName
       quantity
       sellingPrice


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add fields `productRefId`, `additionalInfo`, `productCategoryIds`, `productCategories` to cart related queries: `orderForm`, `addToCart` and `updateItems`.

#### What problem is this solving?

Make it possible to trigger addToCart and removeFromCart evens in Google Tag Manager.

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/

#### Screenshots or example usage

n/a

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
