### PR TITLE
Add install prompt settings to pwa context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- More options to show `Add to home screen` prompt.
+- Add prompt settings in context.
 
 ## [0.20.0] - 2019-08-09
 

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -15,8 +15,8 @@ const PWAProvider = ({ settings, children }) => {
 
   useEffect(() => {
     const handleBeforeInstall = e => {
-      const { promptOnCustomEvent } = settings
-      if (promptOnCustomEvent && !captured.current) {
+      const { addToHomeScreenPrompt } = settings
+      if (addToHomeScreenPrompt !== "default" && !captured.current) {
         e.preventDefault()
         deferredPrompt.current = e
         captured.current = true
@@ -40,7 +40,7 @@ const PWAProvider = ({ settings, children }) => {
     }
   }, [])
 
-  const context = useMemo(() => ({ showInstallPrompt }), [showInstallPrompt])
+  const context = useMemo(() => ({ showInstallPrompt, settings }), [showInstallPrompt, settings])
 
   return <PWAContext.Provider value={context}>{children}</PWAContext.Provider>
 }

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -18,6 +18,10 @@ const PWAProvider = ({ settings, children }) => {
       const { addToHomeScreenPrompt } = settings
       if (addToHomeScreenPrompt !== "default" && !captured.current) {
         e.preventDefault()
+        
+        if(addToHomeScreenPrompt === "disable")
+          return false
+        
         deferredPrompt.current = e
         captured.current = true
         return false

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -19,9 +19,10 @@ const PWAProvider = ({ settings, children }) => {
       if (addToHomeScreenPrompt !== "default" && !captured.current) {
         e.preventDefault()
         
-        if(addToHomeScreenPrompt === "disable")
+        if(addToHomeScreenPrompt === "disable") {
           return false
-        
+        }
+
         deferredPrompt.current = e
         captured.current = true
         return false

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -19,7 +19,7 @@ const PWAProvider = ({ settings, children }) => {
       if (addToHomeScreenPrompt !== "default" && !captured.current) {
         e.preventDefault()
         
-        if(addToHomeScreenPrompt === "disable") {
+        if (addToHomeScreenPrompt === "disable") {
           return false
         }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
Exist some Patterns to show the install prompt to promote PWA app. We need to give the options in the store settings.

#### How should this be manually tested?
[Workspace with item added to cart configured](https://promptbutton--storecomponents.myvtex.com/)
[Workspace with order placed configured](https://orderprompt--storecomponents.myvtex.com/checkout/orderPlaced/?og=949500478939)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
