### PR TITLE
Add promptOnCustomEvent in PWA Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `promptOnCustomEvent` in `PWAContext`.
 
 ## [0.23.0] - 2019-08-29
 ### Changed

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -25,7 +25,7 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
       if (promptOnCustomEvent !== 'default' && !captured.current) {
         e.preventDefault()
 
-        if(disablePrompt) {
+        if (disablePrompt) {
           return false
         }
 

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -22,7 +22,7 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
   useEffect(() => {
     const handleBeforeInstall = e => {
       const { promptOnCustomEvent, disablePrompt } = pwaSettings
-      if (promptOnCustomEvent !== "default" && !captured.current) {
+      if (promptOnCustomEvent !== 'default' && !captured.current) {
         e.preventDefault()
 
         if(disablePrompt) {

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -57,7 +57,7 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
       return {
         showInstallPrompt,
         settings: {
-          promptOnCustomEvent: disablePrompt ? "" : promptOnCustomEvent
+          promptOnCustomEvent: disablePrompt ? '' : promptOnCustomEvent
         }
       }
     }

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -52,7 +52,7 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
   }, [])
 
   const context = useMemo(() => {
-    if(pwaSettings) {
+    if (pwaSettings) {
       const { disablePrompt, promptOnCustomEvent } = pwaSettings
       return {
         showInstallPrompt,

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -21,9 +21,14 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
 
   useEffect(() => {
     const handleBeforeInstall = e => {
-      const { promptOnCustomEvent } = pwaSettings
-      if (promptOnCustomEvent && !captured.current) {
+      const { promptOnCustomEvent, disablePrompt } = pwaSettings
+      if (promptOnCustomEvent !== "default" && !captured.current) {
         e.preventDefault()
+
+        if(disablePrompt) {
+          return false
+        }
+
         deferredPrompt.current = e
         captured.current = true
         return false
@@ -46,7 +51,18 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
     }
   }, [])
 
-  const context = useMemo(() => ({ showInstallPrompt }), [showInstallPrompt])
+  const context = useMemo(() => {
+    if(pwaSettings) {
+      const { disablePrompt, promptOnCustomEvent } = pwaSettings
+      return {
+        showInstallPrompt,
+        settings: {
+          promptOnCustomEvent: disablePrompt ? "" : promptOnCustomEvent
+        }
+      }
+    }
+  }, [showInstallPrompt, pwaSettings])
+
   const hasManifest = !loading && manifest && !error
 
   return (

--- a/react/queries/pwaData.gql
+++ b/react/queries/pwaData.gql
@@ -1,6 +1,6 @@
 query pwaData {
   pwaSettings {
-    disablePrompt,
+    disablePrompt
     promptOnCustomEvent
   }
   manifest {

--- a/react/queries/pwaData.gql
+++ b/react/queries/pwaData.gql
@@ -1,5 +1,6 @@
 query pwaData {
   pwaSettings {
+    disablePrompt,
     promptOnCustomEvent
   }
   manifest {


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
Allow more options of events for the install prompt in PWA.

#### How should this be manually tested?
[Workspace](https://thay--storecomponents.myvtex.com)

This workspace is configured to prompt when an item is added to cart.

_Obs_: This prompt is showed only once, if you want to test more times, go to `chrome://flags/#enable-app-banners` and `chrome://flags/#bypass-app-banner-engagement-checks` in your chrome, and change these flags to **enabled**

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.

Related: vtex-apps/store-components#570 , vtex-apps/admin-pages#261