### PR TITLE
remove title tag from productSearch query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- titletag and metaTagDescription resolvers from productSearch. They are used from the searchMetadata query and are unneeded.
 
 ## [0.26.0] - 2019-09-10
 ### Changed

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -19,8 +19,6 @@ query search(
     to: $to
     hideUnavailableItems: $hideUnavailableItems
   ) @context(provider: "vtex.search-graphql") {
-    titleTag
-    metaTagDescription
     products {
       cacheId
       productId


### PR DESCRIPTION
#### What is the purpose of this pull request?

- titleTag and metaTagDescription are now fetched in their own query. They are unneeded. This is a minor performance boost.

#### How should this be manually tested?

https://title--exitocol.myvtex.com
title--samsungar.myvtex.com
https://title--boticario.myvtex.com/
https://title--tbb.myvtex.com/cabelos/tratamento
https://title--parquedpedro.myvtex.com/

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
