### PR TITLE
add clusterHighlights in productSearchV2 querie

### DIFF
--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -82,6 +82,10 @@ query search(
         id
         name
       }
+      clusterHighlights {
+        id
+        name
+      }
       properties {
         name
         values


### PR DESCRIPTION
Adding the clusterHighlights in the shelf we have flexibility so the customer is able to create collections and choose which one of them will show like 'flags'.

**issue - Add clusterHighlights in search-result #115**