### PR TITLE
Disable install prompt for iOS devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Disable install prompt in PWA for IOS Devices.
+- Disable install prompt in PWA for iOS Devices.
 
 ## [0.29.0] - 2019-09-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Disable install prompt in PWA for IOS Devices.
 
 ## [0.29.0] - 2019-09-20
 ### Added

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -54,10 +54,12 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
   const context = useMemo(() => {
     if (pwaSettings) {
       const { disablePrompt, promptOnCustomEvent } = pwaSettings
+      const isIOS = window && window.navigator && !!window.navigator.userAgent.match(/(iPod|iPhone|iPad)/)
+
       return {
         showInstallPrompt,
         settings: {
-          promptOnCustomEvent: disablePrompt ? '' : promptOnCustomEvent
+          promptOnCustomEvent: disablePrompt || isIOS ? '' : promptOnCustomEvent
         }
       }
     }

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -54,7 +54,7 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
   const context = useMemo(() => {
     if (pwaSettings) {
       const { disablePrompt, promptOnCustomEvent } = pwaSettings
-      const isIOS = window && window.navigator && !!window.navigator.userAgent.match(/(iPod|iPhone|iPad)/)
+      const isIOS = navigator && !!navigator.userAgent.match(/(iPod|iPhone|iPad)/)
 
       return {
         showInstallPrompt,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Disable install prompt for IOS devices to not show promotion banner for iOS users.

#### What problem is this solving?
iOS users don't have support for installing web apps, so I'm disabling install prompt to prevent us of promoting installation for these users. 
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[Workspace](https://thay--storecomponents.myvtex.com/)
#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
