### PR TITLE
Adding teaser details in Product and ProductSearchV2 queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `condition` and `effects` to `Teaser` field on `Product` and `ProductSearchV2` queries.
 
 ## [0.30.0] - 2019-10-03
 ### Added

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -79,7 +79,6 @@ query Product(
                 value
               }
             }
-            __typename
           }
           Price
           ListPrice

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -66,6 +66,20 @@ query Product(
           }
           teasers {
             name
+            conditions {
+              minimumQuantity
+              parameters {
+                name
+                value
+              }
+            }
+            effects {
+              parameters {
+                name
+                value
+              }
+            }
+            __typename
           }
           Price
           ListPrice

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -81,7 +81,6 @@ query search(
                   value
                 }
               }
-              __typename
             }
             Installments(criteria: MAX) {
               Value

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -68,6 +68,20 @@ query search(
             }
             teasers {
               name
+              conditions {
+                minimumQuantity
+                parameters {
+                  name
+                  value
+                }
+              }
+              effects {
+                parameters {
+                  name
+                  value
+                }
+              }
+              __typename
             }
             Installments(criteria: MAX) {
               Value


### PR DESCRIPTION
#### What problem is this solving?
Get condition and effects of Teasers on Product type.

#### How should this be manually tested?

[Workspace](https://vtexcamilo--exito.myvtex.com/_v/private/vtex.search-graphql@0.5.0/graphiql/v1?operationName=Product&variables=%7B%0A%20%20%22skipCategoryTree%22%3A%20true%2C%0A%20%20%22slug%22%3A%20%22nevera-himalaya-445-de-425-60-litros-haceb-no-frost-inox-951992%22%2C%0A%20%20%22identifier%22%3A%20%7B%0A%20%20%20%20%22field%22%3A%20%22id%22%2C%0A%20%20%20%20%22value%22%3A%20%22951992%22%0A%20%20%7D%0A%7D)

[Query](https://paste.ofcode.org/CstYmjm2MsP2knUdMFk6Bf)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
