### PR TITLE
Block prompt when is already installed or user dismissed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Check if user already dismissed app installation using local storage variable.
+- Check if user already installed app by checking display mode.
 
 ## [0.30.1] - 2019-10-14
 

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -79,7 +79,7 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
         }
       }
     }
-  }, [showInstallPrompt, pwaSettings, alreadyInstalled])
+  }, [showInstallPrompt, pwaSettings, alreadyInstalled, installDismissed])
 
   const hasManifest = !loading && manifest && !error
 

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -69,6 +69,7 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
   const context = useMemo(() => {
     if (pwaSettings) {
       const { disablePrompt, promptOnCustomEvent } = pwaSettings
+      // ios devices don't have support for installing web apps
       const isIOS = navigator && !!navigator.userAgent.match(/(iPod|iPhone|iPad)/)
 
       return {

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -54,10 +54,14 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
   const context = useMemo(() => {
     if (pwaSettings) {
       const { disablePrompt, promptOnCustomEvent } = pwaSettings
+      const isIOS = navigator && !!navigator.userAgent.match(/(iPod|iPhone|iPad)/)
+      const installDismissed = JSON.parse(localStorage.getItem('appInstallDismissed'))
+      const alreadyInstalled = window.matchMedia('(display-mode: standalone)').matches
       return {
         showInstallPrompt,
         settings: {
-          promptOnCustomEvent: disablePrompt ? '' : promptOnCustomEvent
+          promptOnCustomEvent: disablePrompt || isIOS || installDismissed || alreadyInstalled  ? '' 
+            : promptOnCustomEvent
         }
       }
     }

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -4,11 +4,13 @@ import React, {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react'
 import { Helmet } from 'vtex.render-runtime'
 import { graphql } from 'react-apollo'
 
 import pwaData from './queries/pwaData.gql'
+import webAppAlreadyInstalled from './utils/webAppIndexedDB' 
 
 const PWAContext = React.createContext(null)
 
@@ -18,6 +20,8 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
   const deferredPrompt = useRef(null)
   /* beforeinstallprompt event is fired even after the userChoice is to cancel (and there is no need to re-render) */
   const captured = useRef(false)
+
+  const [alreadyInstalled, setAlreadyInstalled] = useState(false)
 
   useEffect(() => {
     const handleBeforeInstall = e => {
@@ -41,6 +45,13 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
       window.removeEventListener('beforeinstallprompt', handleBeforeInstall)
   }, [captured, pwaSettings])
 
+  useEffect( () => {
+    (async () => {
+      const appIsFromHomeScreen = await webAppAlreadyInstalled()
+      setAlreadyInstalled(appIsFromHomeScreen)
+    })()
+  }, [])
+
   const showInstallPrompt = useCallback(() => {
     const prompt = deferredPrompt.current
     if (prompt) {
@@ -51,21 +62,21 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
     }
   }, [])
 
-  const context = useMemo(() => {
+  const context = useMemo( () => {
     if (pwaSettings) {
       const { disablePrompt, promptOnCustomEvent } = pwaSettings
       const isIOS = navigator && !!navigator.userAgent.match(/(iPod|iPhone|iPad)/)
       const installDismissed = JSON.parse(localStorage.getItem('appInstallDismissed'))
-      const alreadyInstalled = window.matchMedia('(display-mode: standalone)').matches
+
       return {
         showInstallPrompt,
         settings: {
-          promptOnCustomEvent: disablePrompt || isIOS || installDismissed || alreadyInstalled  ? '' 
+          promptOnCustomEvent: (disablePrompt || isIOS || installDismissed || alreadyInstalled) ? '' 
             : promptOnCustomEvent
         }
       }
     }
-  }, [showInstallPrompt, pwaSettings])
+  }, [showInstallPrompt, pwaSettings, alreadyInstalled])
 
   const hasManifest = !loading && manifest && !error
 

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -46,7 +46,7 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
       window.removeEventListener('beforeinstallprompt', handleBeforeInstall)
   }, [captured, pwaSettings])
 
-  useEffect( () => {
+  useEffect(() => {
     (async () => {
       const appIsFromHomeScreen = await getWebAppData('appIsFromHomeScreen')
       setAlreadyInstalled(appIsFromHomeScreen)
@@ -66,7 +66,7 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
     }
   }, [])
 
-  const context = useMemo( () => {
+  const context = useMemo(() => {
     if (pwaSettings) {
       const { disablePrompt, promptOnCustomEvent } = pwaSettings
       const isIOS = navigator && !!navigator.userAgent.match(/(iPod|iPhone|iPad)/)

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -10,7 +10,7 @@ import { Helmet } from 'vtex.render-runtime'
 import { graphql } from 'react-apollo'
 
 import pwaData from './queries/pwaData.gql'
-import webAppAlreadyInstalled from './utils/webAppIndexedDB' 
+import getWebAppData from './utils/webAppIndexedDB' 
 
 const PWAContext = React.createContext(null)
 
@@ -22,6 +22,7 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
   const captured = useRef(false)
 
   const [alreadyInstalled, setAlreadyInstalled] = useState(false)
+  const [installDismissed, setInstallDismissed] = useState(false)
 
   useEffect(() => {
     const handleBeforeInstall = e => {
@@ -47,8 +48,11 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
 
   useEffect( () => {
     (async () => {
-      const appIsFromHomeScreen = await webAppAlreadyInstalled()
+      const appIsFromHomeScreen = await getWebAppData('appIsFromHomeScreen')
       setAlreadyInstalled(appIsFromHomeScreen)
+      
+      const appInstallDismissed = await getWebAppData('appInstallDismissed')
+      setInstallDismissed(appInstallDismissed)
     })()
   }, [])
 
@@ -66,7 +70,6 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
     if (pwaSettings) {
       const { disablePrompt, promptOnCustomEvent } = pwaSettings
       const isIOS = navigator && !!navigator.userAgent.match(/(iPod|iPhone|iPad)/)
-      const installDismissed = JSON.parse(localStorage.getItem('appInstallDismissed'))
 
       return {
         showInstallPrompt,

--- a/react/package.json
+++ b/react/package.json
@@ -4,6 +4,7 @@
     "react": "^16.6.3"
   },
   "dependencies": {
+    "idb": "^4.0.5",
     "react-apollo": "^2.5.8"
   },
   "version": "0.30.1"

--- a/react/utils/webAppIndexedDB.js
+++ b/react/utils/webAppIndexedDB.js
@@ -1,9 +1,9 @@
 import { openDB } from 'idb' 
 
-const webAppAlreadyInstalled = async () => {
+const getWebAppData = async (key) => {
   const dbPromise = openDB('webApp', 1)
-  const { value = false } = await (await dbPromise).get('webApp', 'appIsFromHomeScreen')
+  const { value = false } = await (await dbPromise).get('webApp', key)
   return value
 }
 
-export default webAppAlreadyInstalled
+export default getWebAppData

--- a/react/utils/webAppIndexedDB.js
+++ b/react/utils/webAppIndexedDB.js
@@ -1,0 +1,9 @@
+import { openDB } from 'idb' 
+
+const webAppAlreadyInstalled = async () => {
+  const dbPromise = openDB('webApp', 1)
+  const { value = false } = await (await dbPromise).get('webApp', 'appIsFromHomeScreen')
+  return value
+}
+
+export default webAppAlreadyInstalled

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -31,6 +31,11 @@ hoist-non-react-statics@^3.3.0:
   dependencies:
     react-is "^16.7.0"
 
+idb@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-4.0.5.tgz#23b930fbb0abce391e939c35b7b31a669e74041f"
+  integrity sha512-P+Fk9HT2h1DhXoE1YNK183SY+CRh2GHNh28de94sGwhe0bUA75JJeVJWt3SenE5p0BXK7maflIq29dl6UZHrFw==
+
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
We are implementing components to promote installation of the web app and these components need to know when the app as already installed or installation was dismissed.

#### How should this be manually tested?
[Workspace](https://thay--storecomponents.myvtex.com/checkout/orderPlaced/?og=949500478939)

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
