### PR TITLE
Add variations to product in query of productSearchV2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Fetch `variations` attribute of `product` from `productSearchV2` query.
 
 ## [0.31.0] - 2019-10-14 [YANKED]
 ### Added

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -45,6 +45,10 @@ query search(
         nameComplete
         complementName
         ean
+        variations {
+          name
+          values
+        }
         referenceId {
           Key
           Value


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add missing property of `items` in `products` from `productSearchV2`query.

#### What problem is this solving?

This attribute is necessary in order to use `SKUSelector` inside of `ProductSummary`.

#### How should this be manually tested?

[workspace](https://skuinsummary--storecomponents.myvtex.com/classic?_q=classic&map=ft)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
