### PR TITLE
Add new filtering arguments to productSearchV2 query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `category`, `collection` and `specificationFilters` arguments to `productSearchV2` query.
 
 ## [0.32.0] - 2019-10-14
 ### Added

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -3,6 +3,9 @@ query search(
   $map: String
   $facetQuery: String
   $facetMap: String
+  $category: String
+  $collection: String
+  $specificationFilters: [String]
   $orderBy: String
   $priceRange: String
   $from: Int
@@ -13,6 +16,9 @@ query search(
   productSearch(
     query: $query
     map: $map
+    category: $category
+    collection: $collection
+    specificationFilters: $specificationFilters
     orderBy: $orderBy
     priceRange: $priceRange
     from: $from


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add more arguments to the `productSearchV2` query:

- `category`
- `collection`
- `specificationFilters`

#### What problem is this solving?

Those arguments are useful for `ProductSummaryList`, which requires the same arguments that the `Shelf` component uses to perform its query for a product list.

#### How should this be manually tested?

https://victorhmp--storecomponents.myvtex.com/about-us

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
