### PR TITLE
Chore/split into files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Separate entry points for each query and mutation
 
 ## [0.45.0] - 2020-02-12
 ### Added

--- a/react/MutationAddToCart.js
+++ b/react/MutationAddToCart.js
@@ -1,0 +1,3 @@
+import addToCart from './mutations/addToCart.gql'
+
+export default addToCart

--- a/react/MutationUpdateItems.js
+++ b/react/MutationUpdateItems.js
@@ -1,0 +1,3 @@
+import updateItems from './mutations/updateItems.gql'
+
+export default updateItems

--- a/react/MutationUpdateOrderFormCheckin.js
+++ b/react/MutationUpdateOrderFormCheckin.js
@@ -1,0 +1,3 @@
+import updateOrderFormCheckin from './mutations/updateOrderFormCheckin.gql'
+
+export default updateOrderFormCheckin

--- a/react/MutationUpdateOrderFormProfile.js
+++ b/react/MutationUpdateOrderFormProfile.js
@@ -1,0 +1,3 @@
+import updateOrderFormProfile from './mutations/updateOrderFormProfile.gql'
+
+export default updateOrderFormProfile

--- a/react/MutationUpdateOrderFormShipping.js
+++ b/react/MutationUpdateOrderFormShipping.js
@@ -1,0 +1,3 @@
+import updateOrderFormShipping from './mutations/updateOrderFormShipping.gql'
+
+export default updateOrderFormShipping

--- a/react/Mutations.js
+++ b/react/Mutations.js
@@ -1,3 +1,6 @@
+/** DEPRECATED, being kept just for retrocompatibility.
+ * Create individual entry points for each mutation instead */
+
 import addToCart from './mutations/addToCart.gql'
 import updateItems from './mutations/updateItems.gql'
 import updateOrderFormProfile from './mutations/updateOrderFormProfile.gql'

--- a/react/Queries.js
+++ b/react/Queries.js
@@ -1,3 +1,6 @@
+/** DEPRECATED, being kept just for retrocompatibility.
+ * Create individual entry points for each query instead */
+
 import orderForm from './queries/orderForm.gql'
 import product from './queries/product.gql'
 import productPreviewFragment from './queries/productPreview.gql'

--- a/react/QueryAddress.js
+++ b/react/QueryAddress.js
@@ -1,0 +1,3 @@
+import address from './queries/address.gql'
+
+export default address

--- a/react/QueryFacets.js
+++ b/react/QueryFacets.js
@@ -1,0 +1,3 @@
+import facets from './queries/facets.gql'
+
+export default facets

--- a/react/QueryOrderForm.js
+++ b/react/QueryOrderForm.js
@@ -1,0 +1,3 @@
+import orderForm from './queries/orderForm.gql'
+
+export default orderForm

--- a/react/QueryProduct.js
+++ b/react/QueryProduct.js
@@ -1,0 +1,3 @@
+import product from './queries/product.gql'
+
+export default product

--- a/react/QueryProductBenefits.js
+++ b/react/QueryProductBenefits.js
@@ -1,0 +1,3 @@
+import productBenefits from './queries/productBenefits.gql'
+
+export default productBenefits

--- a/react/QueryProductPreviewFragment.js
+++ b/react/QueryProductPreviewFragment.js
@@ -1,0 +1,3 @@
+import productPreviewFragment from './queries/productPreview.gql'
+
+export default productPreviewFragment

--- a/react/QueryProductSearch.js
+++ b/react/QueryProductSearch.js
@@ -1,0 +1,3 @@
+import productSearch from './queries/productSearch.gql'
+
+export default productSearch

--- a/react/QueryProductSearchV2.js
+++ b/react/QueryProductSearchV2.js
@@ -1,0 +1,3 @@
+import productSearchV2 from './queries/productSearchV2.gql'
+
+export default productSearchV2

--- a/react/QueryRecommendationsAndBenefits.js
+++ b/react/QueryRecommendationsAndBenefits.js
@@ -1,0 +1,3 @@
+import recommendationsAndBenefits from './queries/recommendationsAndBenefits.gql'
+
+export default recommendationsAndBenefits

--- a/react/QuerySearch.js
+++ b/react/QuerySearch.js
@@ -1,0 +1,3 @@
+import search from './queries/search.gql'
+
+export default search

--- a/react/QuerySearchMetadata.js
+++ b/react/QuerySearchMetadata.js
@@ -1,0 +1,3 @@
+import searchMetadata from './queries/searchMetadata.gql'
+
+export default searchMetadata

--- a/react/QuerySession.js
+++ b/react/QuerySession.js
@@ -1,0 +1,3 @@
+import session from './queries/session.gql'
+
+export default session

--- a/react/QueryUNSTABLEProductCategoryTree.js
+++ b/react/QueryUNSTABLEProductCategoryTree.js
@@ -1,0 +1,3 @@
+import productCategoryTree from './queries/UNSTABLE__productCategoryTree.gql'
+
+export default productCategoryTree


### PR DESCRIPTION
#### What is the purpose of this pull request?
Create separate entry points for each query and mutation.

Big `export default`ed objects are not properly trimmed and "tree-shaken", and result in large payloads and longer load times

Queries and mutations should now be imported like:
`import addToCart from 'vtex.store-resources/MutationAddToCart'`

instead of

`import { addToCart } from 'vtex.store-resources'`

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
