### PR TITLE
Add new fields to orderForm query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `lastName` field to `clientProfileData` field in `orderForm` query.
+- `userProfileId` field to `orderForm` query.
 
 ## [0.40.0] - 2020-01-02
 ### Added

--- a/react/queries/orderForm.gql
+++ b/react/queries/orderForm.gql
@@ -2,6 +2,7 @@ query orderForm {
   orderForm {
     cacheId
     orderFormId
+    userProfileId
     customData {
       customApps {
         id
@@ -110,6 +111,7 @@ query orderForm {
     clientProfileData {
       email
       firstName
+      lastName
     }
     storePreferencesData {
       countryCode


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `lastName` field to `clientProfileData` field and `userProfileId` field to `orderForm` query.

#### What problem is this solving?

Those fields wore exposed by `store-graphql` and we were not fetching them, but now they are needed.

#### How should this be manually tested?

[Workspace](https://victorhmp--storecomponents.myvtex.com/_v/private/vtex.store-resources@0.40.0/graphiql/v1?operationName=orderForm)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
