### PR TITLE
Add `skuSpecifications` on `product`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+-  `skuSpecifications` on the `product` query.
 
 ## [0.41.0] - 2020-01-04
 ### Added

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -169,6 +169,14 @@ query Product(
         required
       }
     }
+    skuSpecifications {
+      field {
+        name
+      }
+      values {
+        name
+      }
+    }
     itemMetadata {
       items {
         id


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add new prop skuSpecifications on the Product query. Needs https://github.com/vtex-apps/search-graphql/pull/42

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/classic-shoes/p)

Open the console and check that valuesFromContext -> product. skuSpecifications exists
