### PR TITLE
Facets compatibility args for new search URL structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add queryArgs field to facets resolver for new search URLs structure
 
 ## [0.43.0] - 2020-01-24
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-resources",
-  "version": "0.43.0",
+  "version": "0.44.0-beta.0",
   "title": "VTEX Store Resources",
   "description": "Common VTEX Store Resources",
   "builders": {

--- a/react/queries/facets.gql
+++ b/react/queries/facets.gql
@@ -99,5 +99,9 @@ query facets(
       slug
       map
     }
+    queryArgs {
+      query
+      map
+    }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add queryArgs to facets resolver

<!--- Describe your changes in detail. -->
Added a field called queryArgs that has {query, map} values

#### What problem is this solving?
We need a way to keep track of the old facets query and map values, since our new search URLs doesn't have the complete information anymore. This makes search-result understand both formats url formats the new one and de legacy ones.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
