### PR TITLE
Added `imagePerSKUQuantity` on `product` arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `imagePerSKUQuantity` on `product` arguments.
 
 ## [0.45.0] - 2020-02-12
 ### Added

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -1,7 +1,7 @@
 query Product(
   $slug: String
   $identifier: ProductUniqueIdentifier
-  $imagePerSKUQuantity: Int = 10
+  $imageQuantity: Int = 10
   $skipCategoryTree: Boolean = false
 ) {
   product(slug: $slug, identifier: $identifier)
@@ -46,7 +46,7 @@ query Product(
       }
       measurementUnit
       unitMultiplier
-      images(quantity: $imagePerSKUQuantity) {
+      images(quantity: $imageQuantity) {
         imageId
         imageLabel
         imageTag

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -1,6 +1,7 @@
 query Product(
   $slug: String
   $identifier: ProductUniqueIdentifier
+  $imagePerSKUQuantity: Int = 10
   $skipCategoryTree: Boolean = false
 ) {
   product(slug: $slug, identifier: $identifier)
@@ -45,7 +46,7 @@ query Product(
       }
       measurementUnit
       unitMultiplier
-      images(quantity: 10) {
+      images(quantity: $imagePerSKUQuantity) {
         imageId
         imageLabel
         imageTag


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says. This was necessary so the stores can change the number of images that every SKU will show.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/classic-shoes/p)
On this workspace this value is set to `1` so each SKU will only have one item.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/74373865-0c134000-4dbc-11ea-8426-d622b2edda87.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
