### PR TITLE
Query for a new `gifts` field added to `Offer` type from search-graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `gifts` field to product queries.
 
 ## [0.49.0] - 2020-03-02
 ### Added

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -100,8 +100,7 @@ query Product(
             brand
             linkText
             description
-            productTitle
-            nameComplete
+            skuName
             images {
               imageUrl
               imageLabel

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -95,6 +95,21 @@ query Product(
             NumberOfInstallments
             Name
           }
+          giftSkuIds {
+            productName
+            brand
+            linkText
+            description
+            productTitle
+            skuItem {
+              nameComplete
+              images {
+                imageUrl
+                imageLabel
+                imageText
+              }
+            }
+          }
         }
       }
       variations {

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -95,19 +95,17 @@ query Product(
             NumberOfInstallments
             Name
           }
-          giftSkuIds {
+          gifts {
             productName
             brand
             linkText
             description
             productTitle
-            skuItem {
-              nameComplete
-              images {
-                imageUrl
-                imageLabel
-                imageText
-              }
+            nameComplete
+            images {
+              imageUrl
+              imageLabel
+              imageText
             }
           }
         }

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -116,6 +116,19 @@ query productSearchV2(
             RewardValue
             PriceValidUntil
             AvailableQuantity
+            gifts {
+              productName
+              brand
+              linkText
+              description
+              productTitle
+              nameComplete
+              images {
+                imageUrl
+                imageLabel
+                imageText
+              }
+            }
           }
         }
       }

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -116,18 +116,6 @@ query productSearchV2(
             RewardValue
             PriceValidUntil
             AvailableQuantity
-            gifts {
-              productName
-              brand
-              linkText
-              description
-              skuName
-              images {
-                imageUrl
-                imageLabel
-                imageText
-              }
-            }
           }
         }
       }

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -121,8 +121,7 @@ query productSearchV2(
               brand
               linkText
               description
-              productTitle
-              nameComplete
+              skuName
               images {
                 imageUrl
                 imageLabel


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a new field `gifts` to the `productSearchV2` and `Product` queries.

#### What problem is this solving?

This should enable us to develop a new app that needs that data, such as `vtex.product-gifts`.

#### How should this be manually tested?

This is an example implementation of `product-gifts`:

[Workspace](https://productgifts--storecomponents.myvtex.com/traveler-backpack/p)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.

#### Notes

Depends on:

- https://github.com/vtex-apps/search-graphql/pull/51
