### PR TITLE
Bring back gifts field in product query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `gifts` field to product queries.
 
 ## [0.51.1] - 2020-03-07
 ### Fixed

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -144,6 +144,18 @@ query Product(
               discountHighlights {
                 name
               }
+              gifts {
+                productName
+                brand
+                linkText
+                description
+                skuName
+                images {
+                  imageUrl
+                  imageLabel
+                  imageText
+                }
+              }
               Price
               ListPrice
               PriceWithoutDiscount


### PR DESCRIPTION
#### What is the purpose of this pull request?

There was a bug in the field resolver for the `gifts` field which was fixed by: https://github.com/vtex-apps/search-graphql/pull/55

#### What problem is this solving?

This should enable the `product-gifts` component to function properly.

#### How should this be manually tested?

[Workspace](https://productgifts--tbb.myvtex.com/la-vie-est-belle-eau-de-parfum-lancome-perfume-feminino-804902-p/p?__disableSSR)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
