### PR TITLE
make pwa context use lazy query

### DIFF
--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -14,8 +14,8 @@ import pwaData from './queries/pwaData.gql'
 
 const PWAContext = React.createContext(null)
 
-const TWO_SECONDS = 2000
-const getTimeout = hints => TWO_SECONDS * (hints.desktop ? 1 : 2)
+const QUERY_DELAY = 2000
+const getQueryDelay = hints => QUERY_DELAY * (hints.desktop ? 1 : 2)
 
 const PWAProvider = ({ rootPath, children }) => {
   const [loadPwa, { called, loading, data = {} }] = useLazyQuery(pwaData, { ssr: false })
@@ -32,10 +32,11 @@ const PWAProvider = ({ rootPath, children }) => {
 
   useEffect(() => {
     window.addEventListener('load', () => {
-      const timeout = getTimeout(hints)
+      const timeout = getQueryDelay(hints)
       const requestIdleCallback = window.requestIdleCallback || function cb(fn) {
         setTimeout(fn, timeout)
       }
+      // On browsers that don't support requestIdleCallback (i.e. Safari) falls back to a timeout
       requestIdleCallback(() => {
         loadPwa()
       }, { timeout })

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -6,17 +6,22 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { Helmet } from 'vtex.render-runtime'
-import { graphql } from 'react-apollo'
+import { Helmet, useRuntime } from 'vtex.render-runtime'
+import { useLazyQuery } from 'react-apollo'
 import { usePixel } from 'vtex.pixel-manager/PixelContext'
 
 import pwaData from './queries/pwaData.gql'
 
 const PWAContext = React.createContext(null)
 
-const PWAProvider = ({ rootPath, children, data = {} }) => {
-  const { manifest, iOSIcons, splashes, pwaSettings, loading, error } = data
+const TWO_SECONDS = 2000
+const getTimeout = hints => TWO_SECONDS * (hints.desktop ? 1 : 2)
+
+const PWAProvider = ({ rootPath, children }) => {
+  const [loadPwa, { called, loading, data = {} }] = useLazyQuery(pwaData, { ssr: false })
+  const { manifest, iOSIcons, splashes, pwaSettings, error } = data
   const { push } = usePixel()
+  const { hints } = useRuntime()
 
   const deferredPrompt = useRef(null)
   /* beforeinstallprompt event is fired even after the userChoice is to cancel (and there is no need to re-render) */
@@ -25,6 +30,17 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
   const [alreadyInstalled, setAlreadyInstalled] = useState(false)
   const [installDismissed, setInstallDismissed] = useState(false)
 
+  useEffect(() => {
+    window.addEventListener('load', () => {
+      const timeout = getTimeout(hints)
+      const requestIdleCallback = window.requestIdleCallback || function cb(fn) {
+        setTimeout(fn, timeout)
+      }
+      requestIdleCallback(() => {
+        loadPwa()
+      }, { timeout })
+    }, { once: true })
+  }, [])
 
   useEffect(() => {
     const handleBeforeInstall = e => {
@@ -48,7 +64,7 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
       window.removeEventListener('beforeinstallprompt', handleBeforeInstall)
   }, [captured, pwaSettings])
 
-  useEffect( () => {
+  useEffect(() => {
     const webAppInstalled = localStorage.getItem('webAppInstalled')
     if (webAppInstalled) {
       setAlreadyInstalled(webAppInstalled)
@@ -78,7 +94,7 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
     }
   }, [])
 
-  const context = useMemo( () => {
+  const context = useMemo(() => {
     if (pwaSettings) {
       const { disablePrompt, promptOnCustomEvent } = pwaSettings
       /* browsers for ios devices doesn't support install prompt */
@@ -87,14 +103,14 @@ const PWAProvider = ({ rootPath, children, data = {} }) => {
       return {
         showInstallPrompt,
         settings: {
-          promptOnCustomEvent: (disablePrompt || isIOS || installDismissed || alreadyInstalled) ? '' 
+          promptOnCustomEvent: (disablePrompt || isIOS || installDismissed || alreadyInstalled) ? ''
             : promptOnCustomEvent
         }
       }
     }
   }, [showInstallPrompt, pwaSettings, alreadyInstalled])
 
-  const hasManifest = !loading && manifest && !error
+  const hasManifest = called && !loading && manifest && !error
 
   return (
     <PWAContext.Provider value={context}>
@@ -135,10 +151,4 @@ const usePWA = () => {
   return useContext(PWAContext)
 }
 
-const options = {
-  options: () => ({
-    ssr: false,
-  }),
-}
-
-export default { PWAContext, PWAProvider: graphql(pwaData, options)(PWAProvider), usePWA }
+export default { PWAContext, PWAProvider, usePWA }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Instead of doing the query and take processing time during the first page load, wait for the load event before firing the pwa query

#### What problem is this solving?

https://fidelis--alssports.myvtex.com/

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
