### PR TITLE
Get product estimated arrival date in product query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Get product estimated arrival date in product query.
 
 ## [0.51.1] - 2020-03-07
 ### Fixed

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -168,6 +168,7 @@ query Product(
         name
         required
       }
+      estimatedDateArrival
     }
     skuSpecifications {
       field {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To add `estimatedDateArrival` to the result of the product query.

https://app.clubhouse.io/vtex/story/33405/add-estimateddatearrival-to-product-query

#### What problem is this solving?

See slack thread: https://vtex.slack.com/archives/C9P4RMW6Q/p1583949574316900

#### How should this be manually tested?

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
