### PR TITLE
Fix/revert lazy pwa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where lazy PWA would prevent PWA features from working (reverts 0.52.1)
 
 ## [0.56.1] - 2020-04-14
 ### Fixed

--- a/react/PWAContext.js
+++ b/react/PWAContext.js
@@ -6,22 +6,17 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { Helmet, useRuntime } from 'vtex.render-runtime'
-import { useLazyQuery } from 'react-apollo'
+import { Helmet } from 'vtex.render-runtime'
+import { graphql } from 'react-apollo'
 import { usePixel } from 'vtex.pixel-manager/PixelContext'
 
 import pwaData from './queries/pwaData.gql'
 
 const PWAContext = React.createContext(null)
 
-const QUERY_DELAY = 2000
-const getQueryDelay = hints => QUERY_DELAY * (hints.desktop ? 1 : 2)
-
-const PWAProvider = ({ rootPath, children }) => {
-  const [loadPwa, { called, loading, data = {} }] = useLazyQuery(pwaData, { ssr: false })
-  const { manifest, iOSIcons, splashes, pwaSettings, error } = data
+const PWAProvider = ({ rootPath, children, data = {} }) => {
+  const { manifest, iOSIcons, splashes, pwaSettings, loading, error } = data
   const { push } = usePixel()
-  const { hints } = useRuntime()
 
   const deferredPrompt = useRef(null)
   /* beforeinstallprompt event is fired even after the userChoice is to cancel (and there is no need to re-render) */
@@ -30,18 +25,6 @@ const PWAProvider = ({ rootPath, children }) => {
   const [alreadyInstalled, setAlreadyInstalled] = useState(false)
   const [installDismissed, setInstallDismissed] = useState(false)
 
-  useEffect(() => {
-    window.addEventListener('load', () => {
-      const timeout = getQueryDelay(hints)
-      const requestIdleCallback = window.requestIdleCallback || function cb(fn) {
-        setTimeout(fn, timeout)
-      }
-      // On browsers that don't support requestIdleCallback (i.e. Safari) falls back to a timeout
-      requestIdleCallback(() => {
-        loadPwa()
-      }, { timeout })
-    }, { once: true })
-  }, [])
 
   useEffect(() => {
     const handleBeforeInstall = e => {
@@ -65,7 +48,7 @@ const PWAProvider = ({ rootPath, children }) => {
       window.removeEventListener('beforeinstallprompt', handleBeforeInstall)
   }, [captured, pwaSettings])
 
-  useEffect(() => {
+  useEffect( () => {
     const webAppInstalled = localStorage.getItem('webAppInstalled')
     if (webAppInstalled) {
       setAlreadyInstalled(webAppInstalled)
@@ -95,7 +78,7 @@ const PWAProvider = ({ rootPath, children }) => {
     }
   }, [])
 
-  const context = useMemo(() => {
+  const context = useMemo( () => {
     if (pwaSettings) {
       const { disablePrompt, promptOnCustomEvent } = pwaSettings
       /* browsers for ios devices doesn't support install prompt */
@@ -104,14 +87,14 @@ const PWAProvider = ({ rootPath, children }) => {
       return {
         showInstallPrompt,
         settings: {
-          promptOnCustomEvent: (disablePrompt || isIOS || installDismissed || alreadyInstalled) ? ''
+          promptOnCustomEvent: (disablePrompt || isIOS || installDismissed || alreadyInstalled) ? '' 
             : promptOnCustomEvent
         }
       }
     }
   }, [showInstallPrompt, pwaSettings, alreadyInstalled])
 
-  const hasManifest = called && !loading && manifest && !error
+  const hasManifest = !loading && manifest && !error
 
   return (
     <PWAContext.Provider value={context}>
@@ -152,4 +135,10 @@ const usePWA = () => {
   return useContext(PWAContext)
 }
 
-export default { PWAContext, PWAProvider, usePWA }
+const options = {
+  options: () => ({
+    ssr: false,
+  }),
+}
+
+export default { PWAContext, PWAProvider: graphql(pwaData, options)(PWAProvider), usePWA }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Reverts https://github.com/vtex-apps/store-resources/pull/105

It would cause PWA to not work in some instances.

To test, go to https://lbebber--storecomponents.myvtex.com/ and check that the PWA icon is active (the encircled plus thing)
![Screen Shot 2020-04-17 at 15 35 23](https://user-images.githubusercontent.com/5691711/79602563-135b1080-80c1-11ea-9308-0be7ca61fa10.png)


<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
