### PR TITLE
Add `taxPercentage` on `product`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+-  `taxPercentage` on the `product` query.
 
 ## [0.56.2] - 2020-04-20
 ### Fixed

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -88,6 +88,7 @@ query Product(
           PriceValidUntil
           AvailableQuantity
           Tax
+          taxPercentage
           CacheVersionUsedToCallCheckout
           Installments {
             Value


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `taxPercentage` on `product`

Needs:
https://github.com/vtex-apps/search-resolver/pull/15
https://github.com/vtex-apps/search-graphql/pull/80

#### How should this be manually tested?

[Workspace](https://productprice--storecomponents.myvtex.com/fashion-eyeglasses/p)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/81214953-fd00f000-8fae-11ea-949f-0b72b174119a.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
