### PR TITLE
Add missing productId in updateItems and addItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `updateItems` and `addItem` mutations missing `productId`.
 
-## [0.59.0] - 2020-05-18
+## [0.59.0] - 2020-05-18 [YANKED]
 ### Added
 - `productId` on the `orderForm` query.
 

--- a/react/mutations/addToCart.gql
+++ b/react/mutations/addToCart.gql
@@ -10,6 +10,7 @@ mutation addItem($orderFormId: String, $items: [OrderFormItemInput], $utmParams:
     }
     items {
       id
+      productId
       name
       imageUrl
       detailUrl

--- a/react/mutations/updateItems.gql
+++ b/react/mutations/updateItems.gql
@@ -10,6 +10,7 @@ mutation updateItems($orderFormId: String, $items: [OrderFormItemInput]) {
     }
     items {
       id
+      productId
       name
       imageUrl
       detailUrl


### PR DESCRIPTION
#### What is the purpose of this pull request?

Continuation of #109.

#### What problem is this solving?

Add missing `productId`s in the mutation that return a orderform-like object .

#### How should this be manually tested?

1) goto https://kiwi--exitocol.myvtex.com/toner-para-muslos-verde-miniso-sport-100630688-mp/p
2) click in 'lo quiero''
3) Check if minicart renders the item quantity baloon

#### Screenshots or example usage
n/a

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
