### PR TITLE
add hidden field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add hidden property to facets.
+
 ## [0.60.0] - 2020-06-02
 ### Added
 - `taxPercentage` and `Tax` on `products`, `productSearch`, `productSearchV2` and `productSearchV3` queries.

--- a/react/queries/facetsV2.gql
+++ b/react/queries/facetsV2.gql
@@ -21,6 +21,7 @@ query facetsV2(
     facets {
       name
       type
+      hidden
       facets: values {
         id
         quantity


### PR DESCRIPTION
#### What problem is this solving?

There are some filters that should be hidden in UI. For example, the ones related to collections. This PR adds a `hidden` field to indicate which filter should be hidden.

⚠️ Please, do not merge it before:
- https://github.com/vtex-apps/search-resolver/pull/29
- https://github.com/vtex-apps/search-resolver/pull/28
- https://github.com/vtex-apps/search-graphql/pull/82

#### How should this be manually tested?

[Workspace](https://hiago--storecomponents.myvtex.com/apparel---accessories/clothing/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

