### PR TITLE
Add tax attributes on search queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `taxPercentage` and `Tax` on `products`, `productSearch`, `productSearchV2` and `productSearchV3` queries.
 
 ## [0.59.1] - 2020-05-19
 ### Fixed

--- a/react/queries/productSearch.gql
+++ b/react/queries/productSearch.gql
@@ -53,6 +53,8 @@ query productSearch(
           }
           Price
           ListPrice
+          Tax
+          taxPercentage
           PriceWithoutDiscount
           RewardValue
           PriceValidUntil

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -113,6 +113,8 @@ query productSearchV2(
             }
             Price
             ListPrice
+            Tax
+            taxPercentage
             PriceWithoutDiscount
             RewardValue
             PriceValidUntil

--- a/react/queries/productSearchV3.gql
+++ b/react/queries/productSearchV3.gql
@@ -112,6 +112,8 @@ query productSearchV3(
             }
             Price
             ListPrice
+            Tax
+            taxPercentage
             PriceWithoutDiscount
             RewardValue
             PriceValidUntil

--- a/react/queries/products.gql
+++ b/react/queries/products.gql
@@ -76,6 +76,8 @@ query Products(
           Price
           PriceWithoutDiscount
           ListPrice
+          Tax
+          taxPercentage
           teasers {
             name
           }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds `taxPercentage` and `Tax` on `products`, `productSearch`, `productSearchV2` and `productSearchV3` queries.

#### What problem is this solving?

https://github.com/vtex-apps/product-price/issues/27

#### How should this be manually tested?

[Workspace](https://productprice--storecomponents.myvtex.com/)
[exitocol](https://iaronaraujo--exitocol.myvtex.com/mercado/pollo-carne-y-pescado/pollo)

Check the shelf and search pages

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/82845062-55922180-9eb9-11ea-8db4-664014c986ff.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
