### PR TITLE
Add 'skuSpecifications' field to 'productSearchV3' query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `skuSpecifications` field to `productSearchV3` query.
 
 ## [0.61.0] - 2020-06-17
 

--- a/react/queries/productSearchV3.gql
+++ b/react/queries/productSearchV3.gql
@@ -121,6 +121,14 @@ query productSearchV3(
           }
         }
       }
+      skuSpecifications {
+        field {
+          name
+        }
+        values {
+          name
+        }
+      }
       productClusters {
         id
         name


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the following snippet to the `productSearchV3` query, so that the SKU Selector component has access to this attribute when it's being used inside a `store.search` page.

```graphql
skuSpecifications {
  field {
    name
  }
  values {
    name
  }
}
```

#### What problem is this solving?

The SKU Selector derives the available product variations from its nearest `ProductContext`. When its rendered inside of a `store.product` page, the SKU Selector has access to a `ProductContext` that was populated with the result of a `product` query, which includes this `skuSpecifications` field. It then uses the specifications received from the query to render itself. However, when the SKU Selector is rendered inside a `product-summary` (typically in the form of a `product-summary-sku-selector` block), for example in a `store.search` page, the nearest `ProductContext` was populated by a `productSearchV3` query, which currently does **not** include the `skuSpecifications` field, and the SKU Selector has to assemble the product variations itself in order to render. The problem is that during this assemble process, the specifications did not follow any specific order, resulting in situations like this (notice how the sizes appear to be in random order):

![image-20200706-155418](https://user-images.githubusercontent.com/27777263/86825398-b0489c80-c065-11ea-8ea9-2f1df89d9559.png)

☝️ This is a `product-summary` rendered inside a `modal-layout`, used to achieve a "Quick Buy" experience at Equishopper.

 Also, if we go to the product's page, the order is as expected! This is due to the fact that the specifications in `skuSpecifications` field are already sorted, and the SKU Selector can render them as they came.

<img width="1440" alt="Captura de Tela 2020-07-07 às 15 30 37" src="https://user-images.githubusercontent.com/27777263/86826243-d6bb0780-c066-11ea-8db3-916ccb7ecfbd.png">

With this PR, the behavior described above should not be observed anymore, since in both cases where SKU Selectors are used, the data available to them will be the same.

#### How should this be manually tested?

There are two ways to test this:

1. Go to [Admin GraphQL IDE](https://skuselectordebug--equishopper.myvtex.com/admin/graphql-ide) and perform a `productSearchV3` query with the `skuSpecifications` field to see that it returns correctly;
2. Go to [Equishopper](https://skuselectordebug--equishopper.myvtex.com/riding-apparel), click on the "Quick Shop" button for the first product ("Horze Kid's Active Knee Patch Tights - Peacoat Dark Blue"), notice that the sizes displayed by the SKU Selector are sorted. Now go to this product's page and you should see the same result :)

#### Screenshots or example usage

<img width="1043" alt="Captura de Tela 2020-07-07 às 15 40 22" src="https://user-images.githubusercontent.com/27777263/86827298-32d25b80-c068-11ea-853e-7d9ae85bb8fb.png">

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
