### PR TITLE
Fetch PaymentSystemName from Installments in Product query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `PaymentSystemName` to `Installments of `Product` query.
 
 ## [0.66.0] - 2020-07-22
 ### Added

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -98,6 +98,7 @@ query Product(
             TotalValuePlusInterestRate
             NumberOfInstallments
             Name
+            PaymentSystemName
           }
         }
       }
@@ -162,6 +163,7 @@ query Product(
                 TotalValuePlusInterestRate
                 NumberOfInstallments
                 Name
+                PaymentSystemName
               }
             }
           }

--- a/react/queries/productBenefits.gql
+++ b/react/queries/productBenefits.gql
@@ -67,6 +67,7 @@ query ProductBenefits($slug: String, $identifier: ProductUniqueIdentifier) {
                   TotalValuePlusInterestRate
                   NumberOfInstallments
                   Name
+                  PaymentSystemName
                 }
               }
             }

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -112,6 +112,7 @@ query productSearchV2(
               TotalValuePlusInterestRate
               NumberOfInstallments
               Name
+              PaymentSystemName
             }
             Price
             ListPrice

--- a/react/queries/productSearchV3.gql
+++ b/react/queries/productSearchV3.gql
@@ -111,6 +111,7 @@ query productSearchV3(
               TotalValuePlusInterestRate
               NumberOfInstallments
               Name
+              PaymentSystemName
             }
             Price
             ListPrice

--- a/react/queries/productSuggestions.gql
+++ b/react/queries/productSuggestions.gql
@@ -92,6 +92,7 @@ query productSuggestions(
               TotalValuePlusInterestRate
               NumberOfInstallments
               Name
+              PaymentSystemName
             }
             Price
             ListPrice

--- a/react/queries/recommendationsAndBenefits.gql
+++ b/react/queries/recommendationsAndBenefits.gql
@@ -48,6 +48,7 @@ query RecommendationsAndBenefits(
                 TotalValuePlusInterestRate
                 NumberOfInstallments
                 Name
+                PaymentSystemName
               }
             }
           }
@@ -94,6 +95,7 @@ query RecommendationsAndBenefits(
                 TotalValuePlusInterestRate
                 NumberOfInstallments
                 Name
+                PaymentSystemName
               }
             }
           }
@@ -140,6 +142,7 @@ query RecommendationsAndBenefits(
                 TotalValuePlusInterestRate
                 NumberOfInstallments
                 Name
+                PaymentSystemName
               }
             }
           }
@@ -202,6 +205,7 @@ query RecommendationsAndBenefits(
                   TotalValuePlusInterestRate
                   NumberOfInstallments
                   Name
+                  PaymentSystemName
                 }
               }
             }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `PaymentSystemName` to `Installments` in `Product` in order to use this value in the `vtex.product-price:product-installments` block

#### How should this be manually tested?

1. [workspace](https://installmentslist--storecomponents.myvtex.com/vintage-phone/p)
2. Open apollo devTools and check if the value is coming in the query

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
