### PR TITLE
Add sellerName to products query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `sellerName` to the `products` query.
 
 ## [0.68.0] - 2020-08-12
 

--- a/react/queries/products.gql
+++ b/react/queries/products.gql
@@ -66,6 +66,7 @@ query Products(
       }
       sellers {
         sellerId
+        sellerName
         commertialOffer {
           Installments(criteria: $installmentCriteria) {
             Value


### PR DESCRIPTION
#### What is the purpose of this pull request?



Related https://github.com/vtex-apps/add-to-cart-button/pull/46

**This field is already on other queries: https://github.com/vtex-apps/store-resources/search?q=sellername&unscoped_q=sellername** 


#### What problem is this solving?

Send `sellerName` to pixel events.

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/

Add an item to cart and check the `pixelManagerEvents` variable in the Chrome Dev console.

![image](https://user-images.githubusercontent.com/284515/92522854-c1dd2a80-f1f5-11ea-8edd-4eac35e20407.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
