### PR TITLE
add teasers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add new fields to the teasers from the `products` query.
+
 ## [0.68.0] - 2020-08-12
 
 ### Added

--- a/react/queries/products.gql
+++ b/react/queries/products.gql
@@ -83,6 +83,19 @@ query Products(
           spotPrice
           teasers {
             name
+            conditions {
+              minimumQuantity
+              parameters {
+                name
+                value
+              }
+            }
+            effects {
+              parameters {
+                name
+                value
+              }
+            }
           }
           discountHighlights {
             name


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add new fields to the teasers from the `products` query. We are have this fields on the `productSearch` query, but they are missing on the `products` one.

#### How should this be manually tested?

https://hiago--realplaza.myvtex.com/miniso?map=ft

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
