### PR TITLE
Use fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `productRecommendations` query from vtex.shelf.
+
 ### Changed
 - Use fragments in Product fields, making it easier to add new fields across queries.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use fragments in Product fields, making it easier to add new fields across queries.
 
 ## [0.71.0] - 2020-09-22
 ### Added

--- a/react/QueryProductRecommendations.js
+++ b/react/QueryProductRecommendations.js
@@ -1,0 +1,3 @@
+import productRecommendations from './queries/productRecommendations.gql'
+
+export default productRecommendations

--- a/react/fragments/commertialOffer.graphql
+++ b/react/fragments/commertialOffer.graphql
@@ -1,0 +1,30 @@
+fragment CommertialOfferFragment on Offer {
+  discountHighlights {
+    name
+  }
+  teasers {
+    name
+    conditions {
+      minimumQuantity
+      parameters {
+        name
+        value
+      }
+    }
+    effects {
+      parameters {
+        name
+        value
+      }
+    }
+  }
+  Price
+  ListPrice
+  Tax
+  taxPercentage
+  spotPrice
+  PriceWithoutDiscount
+  RewardValue
+  PriceValidUntil
+  AvailableQuantity
+}

--- a/react/fragments/installment.graphql
+++ b/react/fragments/installment.graphql
@@ -1,0 +1,8 @@
+fragment InstallmentFragment on Installment {
+  Value
+  InterestRate
+  TotalValuePlusInterestRate
+  NumberOfInstallments
+  Name
+  PaymentSystemName
+}

--- a/react/fragments/item.graphql
+++ b/react/fragments/item.graphql
@@ -1,0 +1,25 @@
+fragment ItemFragment on SKU {
+  itemId
+  name
+  nameComplete
+  complementName
+  ean
+  variations {
+    name
+    values
+  }
+  referenceId {
+    Key
+    Value
+  }
+  measurementUnit
+  unitMultiplier
+  images {
+    cacheId
+    imageId
+    imageLabel
+    imageTag
+    imageUrl
+    imageText
+  }
+}

--- a/react/fragments/product.graphql
+++ b/react/fragments/product.graphql
@@ -1,0 +1,53 @@
+fragment ProductFragment on Product {
+  cacheId
+  productId
+  description
+  productName
+  productReference
+  linkText
+  brand
+  brandId
+  link
+  categories
+  priceRange {
+    sellingPrice {
+      highPrice
+      lowPrice
+    }
+    listPrice {
+      highPrice
+      lowPrice
+    }
+  }
+  specificationGroups {
+    name
+    originalName
+    specifications {
+      name
+      originalName
+      values
+    }
+  }
+  skuSpecifications {
+    field {
+      name
+      originalName
+    }
+    values {
+      name
+      originalName
+    }
+  }
+  productClusters {
+    id
+    name
+  }
+  clusterHighlights {
+    id
+    name
+  }
+  properties {
+    name
+    values
+  }
+}

--- a/react/fragments/seller.graphql
+++ b/react/fragments/seller.graphql
@@ -1,0 +1,4 @@
+fragment SellerFragment on Seller {
+  sellerId
+  sellerName
+}

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -1,3 +1,9 @@
+#import '../fragments/product.graphql'
+#import '../fragments/item.graphql'
+#import '../fragments/seller.graphql'
+#import '../fragments/commertialOffer.graphql'
+#import '../fragments/installment.graphql'
+
 query Product(
   $slug: String
   $identifier: ProductUniqueIdentifier
@@ -5,106 +11,31 @@ query Product(
 ) {
   product(slug: $slug, identifier: $identifier)
     @context(provider: "vtex.search-graphql") {
-    cacheId
-    productName
-    productId
-    description
+    ...ProductFragment
     titleTag
     metaTagDescription
-    linkText
-    productReference
     categoryId
-    categories
     categoryTree @skip(if: $skipCategoryTree) {
       id
       name
       href
     }
-    brand
-    brandId
-    properties {
-      name
-      values
-    }
-    specificationGroups {
-      name
-      originalName
-      specifications {
-        name
-        originalName
-        values
-      }
-    }
     items {
-      itemId
-      name
-      nameComplete
-      complementName
-      ean
-      referenceId {
-        Key
-        Value
-      }
-      measurementUnit
-      unitMultiplier
-      images {
-        imageId
-        imageLabel
-        imageTag
-        imageUrl
-        imageText
-      }
+      ...ItemFragment
       videos {
         videoUrl
       }
       sellers {
-        sellerId
-        sellerName
+        ...SellerFragment
         addToCartLink
         sellerDefault
         commertialOffer {
-          discountHighlights {
-            name
-          }
-          teasers {
-            name
-            conditions {
-              minimumQuantity
-              parameters {
-                name
-                value
-              }
-            }
-            effects {
-              parameters {
-                name
-                value
-              }
-            }
-          }
-          Price
-          ListPrice
-          spotPrice
-          PriceWithoutDiscount
-          RewardValue
-          PriceValidUntil
-          AvailableQuantity
-          Tax
-          taxPercentage
+          ...CommertialOfferFragment
           CacheVersionUsedToCallCheckout
           Installments {
-            Value
-            InterestRate
-            TotalValuePlusInterestRate
-            NumberOfInstallments
-            Name
-            PaymentSystemName
+            ...InstallmentFragment
           }
         }
-      }
-      variations {
-        name
-        values
       }
       kitItems {
         itemId
@@ -141,29 +72,13 @@ query Product(
             imageText
           }
           sellers {
-            sellerId
-            sellerName
+            ...SellerFragment
             addToCartLink
             sellerDefault
             commertialOffer {
-              discountHighlights {
-                name
-              }
-              Price
-              ListPrice
-              PriceWithoutDiscount
-              RewardValue
-              PriceValidUntil
-              AvailableQuantity
-              Tax
-              CacheVersionUsedToCallCheckout
+              ...CommertialOfferFragment
               Installments(criteria: MAX) {
-                Value
-                InterestRate
-                TotalValuePlusInterestRate
-                NumberOfInstallments
-                Name
-                PaymentSystemName
+                ...InstallmentFragment
               }
             }
           }
@@ -175,16 +90,6 @@ query Product(
         required
       }
       estimatedDateArrival
-    }
-    skuSpecifications {
-      field {
-        name
-        originalName
-      }
-      values {
-        name
-        originalName
-      }
     }
     itemMetadata {
       items {
@@ -225,14 +130,6 @@ query Product(
           price
         }
       }
-    }
-    productClusters {
-      id
-      name
-    }
-    clusterHighlights {
-      id
-      name
     }
   }
 }

--- a/react/queries/productRecommendations.gql
+++ b/react/queries/productRecommendations.gql
@@ -1,0 +1,27 @@
+#import '../fragments/product.graphql'
+#import '../fragments/item.graphql'
+#import '../fragments/seller.graphql'
+#import '../fragments/commertialOffer.graphql'
+#import '../fragments/installment.graphql'
+
+query ProductRecommendations(
+  $identifier: ProductUniqueIdentifier
+  $type: CrossSelingInputEnum
+) {
+  productRecommendations(identifier: $identifier, type: $type)
+    @context(provider: "vtex.search-graphql") {
+    ...ProductFragment
+    items {
+      ...ItemFragment
+      sellers {
+        ...SellerFragment
+        commertialOffer {
+          ...CommertialOfferFragment
+          Installments(criteria: MAX) {
+            ...InstallmentFragment
+          }
+        }
+      }
+    }
+  }
+}

--- a/react/queries/productSearchV2.gql
+++ b/react/queries/productSearchV2.gql
@@ -1,3 +1,9 @@
+#import '../fragments/product.graphql'
+#import '../fragments/item.graphql'
+#import '../fragments/seller.graphql'
+#import '../fragments/commertialOffer.graphql'
+#import '../fragments/installment.graphql'
+
 query productSearchV2(
   $query: String
   $map: String
@@ -30,109 +36,18 @@ query productSearchV2(
     simulationBehavior: $simulationBehavior
   ) @context(provider: "vtex.search-graphql") {
     products {
-      cacheId
-      productId
-      description
-      productName
-      productReference
-      linkText
-      brand
-      brandId
-      link
-      categories
-      priceRange {
-        sellingPrice {
-          highPrice
-          lowPrice
-        }
-        listPrice {
-          highPrice
-          lowPrice
-        }
-      }
-      specificationGroups {
-        name
-        originalName
-        specifications {
-          name
-          originalName
-          values
-        }
-      }
+      ...ProductFragment
       items(filter: $skusFilter) {
-        itemId
-        name
-        nameComplete
-        complementName
-        ean
-        variations {
-          name
-          values
-        }
-        referenceId {
-          Key
-          Value
-        }
-        measurementUnit
-        unitMultiplier
-        images {
-          cacheId
-          imageId
-          imageLabel
-          imageTag
-          imageUrl
-          imageText
-        }
+        ...ItemFragment
         sellers {
-          sellerId
-          sellerName
+          ...SellerFragment
           commertialOffer {
-            discountHighlights {
-              name
-            }
-            teasers {
-              name
-              conditions {
-                minimumQuantity
-                parameters {
-                  name
-                  value
-                }
-              }
-              effects {
-                parameters {
-                  name
-                  value
-                }
-              }
-            }
+            ...CommertialOfferFragment
             Installments(criteria: $installmentCriteria) {
-              Value
-              InterestRate
-              TotalValuePlusInterestRate
-              NumberOfInstallments
-              Name
-              PaymentSystemName
+              ...InstallmentFragment
             }
-            Price
-            ListPrice
-            Tax
-            taxPercentage
-            spotPrice
-            PriceWithoutDiscount
-            RewardValue
-            PriceValidUntil
-            AvailableQuantity
           }
         }
-      }
-      productClusters {
-        id
-        name
-      }
-      properties {
-        name
-        values
       }
     }
     recordsFiltered

--- a/react/queries/productSearchV3.gql
+++ b/react/queries/productSearchV3.gql
@@ -1,3 +1,9 @@
+#import '../fragments/product.graphql'
+#import '../fragments/item.graphql'
+#import '../fragments/seller.graphql'
+#import '../fragments/commertialOffer.graphql'
+#import '../fragments/installment.graphql'
+
 query productSearchV3(
   $query: String
   $fullText: String
@@ -31,123 +37,22 @@ query productSearchV3(
     searchState: $searchState
   ) @context(provider: "vtex.search-graphql") {
     products {
-      cacheId
-      productId
-      description
-      productName
-      productReference
-      linkText
-      brand
-      brandId
-      link
-      categories
-      priceRange {
-        sellingPrice {
-          highPrice
-          lowPrice
-        }
-        listPrice {
-          highPrice
-          lowPrice
-        }
-      }
-      specificationGroups {
-        name
-        originalName
-        specifications {
-          name
-          originalName
-          values
-        }
-      }
+      ...ProductFragment
       items(filter: $skusFilter) {
-        itemId
-        name
-        nameComplete
-        complementName
-        ean
-        variations {
-          name
-          values
-        }
-        referenceId {
-          Key
-          Value
-        }
-        measurementUnit
-        unitMultiplier
-        images {
-          cacheId
-          imageId
-          imageLabel
-          imageTag
-          imageUrl
-          imageText
-        }
+        ...ItemFragment
         sellers {
-          sellerId
-          sellerName
+          ...SellerFragment
           commertialOffer {
-            discountHighlights {
-              name
-            }
-            teasers {
-              name
-              conditions {
-                minimumQuantity
-                parameters {
-                  name
-                  value
-                }
-              }
-              effects {
-                parameters {
-                  name
-                  value
-                }
-              }
-            }
+            ...CommertialOfferFragment
             Installments(
               criteria: $installmentCriteria
               excludedPaymentSystems: $excludedPaymentSystems
               includedPaymentSystems: $includedPaymentSystems
             ) {
-              Value
-              InterestRate
-              TotalValuePlusInterestRate
-              NumberOfInstallments
-              Name
-              PaymentSystemName
+              ...InstallmentFragment
             }
-            Price
-            ListPrice
-            Tax
-            taxPercentage
-            spotPrice
-            PriceWithoutDiscount
-            RewardValue
-            PriceValidUntil
-            AvailableQuantity
           }
         }
-      }
-      skuSpecifications {
-        field {
-          name
-          originalName
-        }
-        values {
-          name
-          originalName
-        }
-      }
-      productClusters {
-        id
-        name
-      }
-      properties {
-        name
-        values
       }
       selectedProperties {
         key

--- a/react/queries/productSuggestions.gql
+++ b/react/queries/productSuggestions.gql
@@ -100,6 +100,8 @@ query productSuggestions(
             }
             Price
             ListPrice
+            Tax
+            taxPercentage
             PriceWithoutDiscount
             RewardValue
             PriceValidUntil
@@ -108,6 +110,10 @@ query productSuggestions(
         }
       }
       productClusters {
+        id
+        name
+      }
+      clusterHighlights {
         id
         name
       }

--- a/react/queries/products.gql
+++ b/react/queries/products.gql
@@ -1,3 +1,9 @@
+#import '../fragments/product.graphql'
+#import '../fragments/item.graphql'
+#import '../fragments/seller.graphql'
+#import '../fragments/commertialOffer.graphql'
+#import '../fragments/installment.graphql'
+
 query Products(
   $category: String
   $collection: String
@@ -18,98 +24,18 @@ query Products(
     to: $to
     hideUnavailableItems: $hideUnavailableItems
   ) @context(provider: "vtex.search-graphql") {
-    cacheId
-    productId
-    productName
-    productReference
-    description
-    link
-    linkText
-    brand
-    brandId
-    categories
-    priceRange {
-      sellingPrice {
-        highPrice
-        lowPrice
-      }
-      listPrice {
-        highPrice
-        lowPrice
-      }
-    }
-    specificationGroups {
-      name
-      originalName
-      specifications {
-        name
-        originalName
-        values
-      }
-    }
+    ...ProductFragment
     items(filter: $skusFilter) {
-      name
-      itemId
-      measurementUnit
-      unitMultiplier
-      referenceId {
-        Value
-      }
-      images {
-        imageUrl
-        imageTag
-        imageLabel
-      }
-      variations {
-        name
-        values
-      }
+      ...ItemFragment
       sellers {
-        sellerId
+        ...SellerFragment
         commertialOffer {
+          ...CommertialOfferFragment
           Installments(criteria: $installmentCriteria) {
-            Value
-            InterestRate
-            TotalValuePlusInterestRate
-            NumberOfInstallments
-            Name
-          }
-          AvailableQuantity
-          Price
-          PriceWithoutDiscount
-          ListPrice
-          Tax
-          taxPercentage
-          spotPrice
-          teasers {
-            name
-            conditions {
-              minimumQuantity
-              parameters {
-                name
-                value
-              }
-            }
-            effects {
-              parameters {
-                name
-                value
-              }
-            }
-          }
-          discountHighlights {
-            name
+            ...InstallmentFragment
           }
         }
       }
-    }
-    productClusters {
-      id
-      name
-    }
-    properties {
-      name
-      values
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Use fragments in Product fields, making it easier to add new fields across queries.

#### What problem is this solving?

Sometimes we add a new field at one query and forget to update other queries that have a Product, this leads to some product-summary features not to work on some occasions due to a missing field.

Also, moved the [productRecommendations query of vtex.shelf](https://github.com/vtex-apps/shelf/blob/master/react/queries/productRecommendations.gql) to this repo.

Example of PRs that would be immediately solved:
- [Add `spotPrice` to `productRecommendations.gql` #235](https://github.com/vtex-apps/shelf/pull/235)
- [Cluster highlights #121](https://github.com/vtex-apps/store-resources/pull/121)
- [Add sellerName to products query #130](https://github.com/vtex-apps/store-resources/pull/130)

#### How should this be manually tested?

1. alssports which uses search-resolver@1.x: https://brenovtex--alssports.myvtex.com/jacket?_q=jacket&map=ft
2. carrefourbr which uses a different resolver: https://brenovtex--carrefourbr.myvtex.com/Celulares-Smartphones-e-Smartwatches/Smartphones?crfimt=hm-tlink|carrefour|menu|campanha|smartphones|1|120820
3. storecomponents which uses search-resolver@0.x: https://brenovtex--storecomponents.myvtex.com/apparel---accessories/
4. dzarm: https://brenovtex--dzarm.myvtex.com/jeans
5. carrefourbrfood: https://brenovtex--carrefourbrfood.myvtex.com/alimentos-e-bebidas?crfint=hm-tlink|alimentos-e-bebidas|1|ofertas|1

Check:
- Product List (shelf) 
- Search page
- Product page

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/92840374-622e7d00-f3b7-11ea-82c1-43dbda33a3fe.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/3o6MbpIrSAabUuzDVe/giphy.gif)
