### PR TITLE
Add 'excludedPaymentMethods' and 'includedPaymentMethods' arguments to productSearchV3 query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `excludedPaymentSystems` and `includedPaymentSystems` arguments to `productSearchV3` query.
 
 ## [0.69.0] - 2020-09-10
 

--- a/react/queries/productSearchV3.gql
+++ b/react/queries/productSearchV3.gql
@@ -13,6 +13,8 @@ query productSearchV3(
   $fuzzy: String
   $operator: Operator
   $searchState: String
+  $excludedPaymentSystems: [String]
+  $includedPaymentSystems: [String]
 ) {
   productSearch(
     query: $query
@@ -105,7 +107,11 @@ query productSearchV3(
                 }
               }
             }
-            Installments(criteria: $installmentCriteria) {
+            Installments(
+              criteria: $installmentCriteria
+              excludedPaymentSystems: $excludedPaymentSystems
+              includedPaymentSystems: $includedPaymentSystems
+            ) {
               Value
               InterestRate
               TotalValuePlusInterestRate


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add two new arguments to the `productSearchV3` query.

- `excludedPaymentMethods`
- `includedPaymentMethods`

#### What problem is this solving?

These arguments were not being exposed to users, since our default queries did not include them. This should enable us to use these new arguments in `vtex.search-result`.

#### How should this be manually tested?

Go to this [workspace](https://victormiranda--storecomponents.myvtex.com/apparel---accessories/).

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
