### PR TITLE
Add two missing sku data to product context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.71.0] - 2020-09-22
 ### Added
-- Add new fields to the SKU from the `products` query.
+- Add `complementName` and `sellerName` to the SKU on `products` query.
 
 ## [0.70.0] - 2020-09-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.71.0] - 2020-09-22
+### Added
+- Add new fields to the SKU from the `products` query.
+
 ## [0.70.0] - 2020-09-18
 ### Added
 - `excludedPaymentSystems` and `includedPaymentSystems` arguments to `productSearchV3` query.

--- a/react/queries/products.gql
+++ b/react/queries/products.gql
@@ -49,6 +49,7 @@ query Products(
     }
     items(filter: $skusFilter) {
       name
+      complementName
       itemId
       measurementUnit
       unitMultiplier
@@ -66,6 +67,7 @@ query Products(
       }
       sellers {
         sellerId
+        sellerName
         commertialOffer {
           Installments(criteria: $installmentCriteria) {
             Value


### PR DESCRIPTION
#### What is the purpose of this pull request?

Expose two missing sku data to product context, so we don't need to make unnecessary extra requests for such a simple thing. The intent is to present the complementName on product shelves; and also present when the name of the seller of that specific product. With this fix we can access this data from the context using `useProductSummary`.

#### Screenshots or example usage

![Screen Shot 2020-09-22 at 11 35 23](https://user-images.githubusercontent.com/5032844/93897816-ea225a00-fcc8-11ea-86a4-3e698de22b11.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
