### PR TITLE
add misspelled and operator to the productSuggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `misspelled` and `operator` to the `productSuggestions` query.
 
 ## [0.71.0] - 2020-09-22
 ### Added

--- a/react/queries/productSuggestions.gql
+++ b/react/queries/productSuggestions.gql
@@ -13,7 +13,9 @@ query productSuggestions(
     simulationBehavior: $simulationBehavior
   ) @context(provider: "vtex.search-graphql") {
     count
-     products {
+    misspelled
+    operator
+    products {
       cacheId
       productId
       description


### PR DESCRIPTION
#### What is the purpose of this pull request?

`misspelled` and `operator` to the `productSuggestions` query.

#### How should this be manually tested?

[workspace](https://hiago--alssports.myvtex.com/)

By typing in the search-bar the query will be triggered

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
