### PR TITLE
Add 'attachments' field in orderForm query

### DIFF
--- a/react/queries/orderForm.gql
+++ b/react/queries/orderForm.gql
@@ -53,6 +53,10 @@ query orderForm {
         brandName
       }
       canHaveAttachment
+      attachments{
+				name
+				content
+			}
       productCategoryIds
       productCategories
       skuName


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the 'attachments' field to the orderForm query

#### What problem is this solving?

I needed to make use of the attachments for each item on the orderForm

#### How should this be manually tested?

Can be tested when using the orderForm query in the GraphQL IDE, for example, where item attachments will be returned

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/14927925/94750697-083d2980-035d-11eb-929c-e954f2071198.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
