### PR TITLE
Add changes to make enableFiltersFetchOptimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `quantity` and arguments to `facets: values` on `facetsV2`.
 
 ## [0.71.0] - 2020-09-22
 ### Added

--- a/react/queries/facetsV2.gql
+++ b/react/queries/facetsV2.gql
@@ -7,6 +7,8 @@ query facetsV2(
   $fuzzy: String
   $operator: Operator
   $searchState: String
+  $from: Int
+  $to: Int
 ) {
   facets(
     query: $query
@@ -26,7 +28,8 @@ query facetsV2(
       name
       type
       hidden
-      facets: values {
+      quantity
+      facets: values (from: $from, to: $to) {
         id
         quantity
         name


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR adds some changes necessary to make the store setting enableFiltersFetchOptimization work. This setting is responsible for truncating facets after the 10th one and making it possible to fetch the rest with a refetch.

#### What problem is this solving?

Making it possible to enable a setting to improve performance on the FilterNavigator

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/clothing/)

#### Screenshots or example usage

Go to the workspace and then check on the graphql that in the FacetsV2 query the `from` value is 0 and `to` is 10 
![image](https://user-images.githubusercontent.com/8443580/94735403-14b38900-0341-11eb-8807-9bdffb44aa0d.png)
Then, on the `Color` filter, click on `show 4 more` and notice that the query was re-fetched, updating the results with every facet available!

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.

NEEDS
https://github.com/vtex-apps/search-graphql/pull/94
https://github.com/vtex-apps/search-resolver/pull/101