### PR TITLE
Added category to productSearch: values on productSearchV3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `category` to `productSearch: values` on `productSearchV3`.
 
 ## [0.73.0] - 2020-10-08
 ### Added

--- a/react/queries/productSearchV3.gql
+++ b/react/queries/productSearchV3.gql
@@ -7,6 +7,7 @@
 query productSearchV3(
   $query: String
   $fullText: String
+  $category: String
   $selectedFacets: [SelectedFacetInput]
   $orderBy: String
   $from: Int
@@ -25,6 +26,7 @@ query productSearchV3(
   productSearch(
     query: $query
     fullText: $fullText
+    category: $category
     selectedFacets: $selectedFacets
     orderBy: $orderBy
     from: $from


### PR DESCRIPTION
#### What is the purpose of this pull request?

Added `category` to `productSearch: values` on `productSearchV3`

#### What problem is this solving?

`category` field is returning empty on `search-resolver` response. 

#### How should this be manually tested?

PR changes can be tested logging the `productSearch: args` on `search-resolver: index.ts` app

#### Screenshots or example usage
screenshot of productSearch args return on search-resolver app without PR changes
![image](https://user-images.githubusercontent.com/26003016/98120915-59c16280-1e8d-11eb-80cd-e1d6b0616d2e.png)

screenshot of productSearch args return on search-resolver app with PR changes
![image](https://user-images.githubusercontent.com/26003016/98121054-8aa19780-1e8d-11eb-8425-053a4a0b92b8.png)

#### Related to / Depends on

https://github.com/vtex-apps/store-resources/pull/139

https://github.com/vtex-apps/search-result/pull/446


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
