### PR TITLE
Add `categoryId` to `product` fragment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `categoryId` to `product` fragment.
 
 ## [0.75.0] - 2020-12-04
 ### Added

--- a/react/fragments/product.graphql
+++ b/react/fragments/product.graphql
@@ -9,6 +9,7 @@ fragment ProductFragment on Product {
   brandId
   link
   categories
+  categoryId
   priceRange {
     sellingPrice {
       highPrice


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `categoryId`  to `product` fragment. These weren't present in each product's context, preventing apps like `condition.layout` from working in the search product list.

#### How should this be manually tested?

https://kiwi--storecomponents.myvtex.com/apparel---accessories/

Open dev tools and looks for the `potato` log

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/12702016/102919651-0371a880-4468-11eb-9cfc-32d302a1ff54.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
