### PR TITLE
add directive connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `connection` directive to the `productSearchV3`.
+
 ## [0.74.0] - 2020-11-13
 ### Added
 - `misspelled` and `operator` to the `productSuggestions` query.

--- a/react/queries/productSearchV3.gql
+++ b/react/queries/productSearchV3.gql
@@ -35,7 +35,7 @@ query productSearchV3(
     fuzzy: $fuzzy
     operator: $operator
     searchState: $searchState
-  ) @context(provider: "vtex.search-graphql") {
+  ) @connection(key: "productSearch", filter: ["to", "from"]) @context(provider: "vtex.search-graphql")  {
     products {
       ...ProductFragment
       items(filter: $skusFilter) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Due to the apollo cache, there is a desynchronization between the FetchMore component pagination and the cache pagination.

![image](https://user-images.githubusercontent.com/40380674/104735139-ff137500-571f-11eb-8fff-148fc862c87e.png)

This PR applies the [solution](https://www.apollographql.com/docs/react/caching/advanced-topics/#the-connection-directive) recommended by the apollo documentation 

#### How should this be manually tested?

[workspace](https://hiago--eriksbikeshop.myvtex.com/)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.

### Related to

https://github.com/vtex/graphql-server/pull/259
