### PR TITLE
use fragments on productsuggestions query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Use fragments on `produtSuggestions` query.
+
 ## [0.76.0] - 2021-02-01
 
 ### Added

--- a/react/queries/productSuggestions.gql
+++ b/react/queries/productSuggestions.gql
@@ -1,3 +1,9 @@
+#import '../fragments/product.graphql'
+#import '../fragments/item.graphql'
+#import '../fragments/seller.graphql'
+#import '../fragments/commertialOffer.graphql'
+#import '../fragments/installment.graphql'
+
 query productSuggestions(
   $fullText: String!
   $facetKey: String
@@ -18,112 +24,22 @@ query productSuggestions(
     misspelled
     operator
     products {
-      cacheId
-      productId
-      description
-      productName
-      productReference
-      linkText
-      brand
-      brandId
-      link
-      categories
-      priceRange {
-        sellingPrice {
-          highPrice
-          lowPrice
-        }
-        listPrice {
-          highPrice
-          lowPrice
-        }
-      }
-      specificationGroups {
-        name
-        originalName
-        specifications {
-          name
-          originalName
-          values
-        }
-      }
+      ...ProductFragment
       items {
-        itemId
-        name
-        nameComplete
-        complementName
-        ean
-        variations {
-          name
-          values
-        }
-        referenceId {
-          Key
-          Value
-        }
-        measurementUnit
-        unitMultiplier
-        images {
-          cacheId
-          imageId
-          imageLabel
-          imageTag
-          imageUrl
-          imageText
-        }
+        ...ItemFragment
         sellers {
-          sellerId
-          sellerName
+          ...SellerFragment
           commertialOffer {
-            discountHighlights {
-              name
-            }
-            teasers {
-              name
-              conditions {
-                minimumQuantity
-                parameters {
-                  name
-                  value
-                }
-              }
-              effects {
-                parameters {
-                  name
-                  value
-                }
-              }
-            }
+            ...CommertialOfferFragment
             Installments {
-              Value
-              InterestRate
-              TotalValuePlusInterestRate
-              NumberOfInstallments
-              Name
-              PaymentSystemName
+              ...InstallmentFragment
             }
-            Price
-            ListPrice
-            Tax
-            taxPercentage
-            PriceWithoutDiscount
-            RewardValue
-            PriceValidUntil
-            AvailableQuantity
           }
         }
       }
-      productClusters {
-        id
-        name
-      }
-      clusterHighlights {
-        id
-        name
-      }
-      properties {
-        name
-        values
+      selectedProperties {
+        key
+        value
       }
     }
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?

The `productsuggestions` query was missing some product fields. I decided to use the fragments that we already have to solve this kind of problem once and for all.


#### How should this be manually tested?

[workspace](https://hiago--eriksbikeshop.myvtex.com/)
