### PR TITLE
Add shortDescription property in fragment Product on product.graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add `shortDescription` property in fragment `Product` on `product.graphql`
 
 ## [0.77.0] - 2021-02-11
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,4 @@
 **Upcoming documentation:**
 
  - [Added InstallmentCriteria variable](https://github.com/vtex-apps/store-resources/pull/104)
+ - [Add shortDescription property in fragment Product on product.graphql](https://github.com/vtex-apps/store-resources/pull/148)

--- a/react/fragments/product.graphql
+++ b/react/fragments/product.graphql
@@ -2,6 +2,7 @@ fragment ProductFragment on Product {
   cacheId
   productId
   description
+  shortDescription
   productName
   productReference
   linkText


### PR DESCRIPTION
#### What is the purpose of this pull request?

Our customer requested a type of short description to display the products on the shelf following the unit of sale, eg "Banana 200g". Where "Banana" is the name of the product and "200g" is the short description to describe the amount of sale.

#### What problem is this solving?

Problems using partial numbers of weight and price used in products eg: price 1.20 200g but price 5.99 / Kg

#### How should this be manually tested?

#### Screenshots or example usage
![Captura de tela 2021-03-08 152850](https://user-images.githubusercontent.com/18530445/110364827-0c175b00-8023-11eb-80e2-2a6800315d03.png)
Highlighted in red we have the desired short description, while the name "Cenoura" not highlighted is the name of the product

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
