### PR TITLE
add availablequantity to the itemswithsimulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add `availableQuantity` to the `itemsWithSimulation` query.
+
 ## [0.77.0] - 2021-02-11
 
 ### Changed

--- a/react/queries/itemsWithSimulation.gql
+++ b/react/queries/itemsWithSimulation.gql
@@ -3,6 +3,7 @@ query itemsWithSimulation($items: [ItemInput]) {
     itemId
     sellers {
       commertialOffer {
+        AvailableQuantity
         Price
         ListPrice
         PriceValidUntil


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds the `AvailableQuantity` to the `itemsWithSimulationQuery`.  This field is already available on https://github.com/vtex-apps/store-graphql/blob/d77ad82527b0c234a9fb45051b9452b315e38f43/graphql/types/Product.graphql#L175, we just need to add it to the query.

#### How should this be manually tested?

[Wroskpace](https://hiago--carrefourbrfood.myvtex.com/busca/leite)

1. Scroll the page until you are able to see a product price
2. Open the Apollo the dev tools and check the `itemsWithSimulation` query

![image](https://user-images.githubusercontent.com/40380674/110795935-26854a80-8256-11eb-9c9f-2ce4b30e1625.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
