### PR TITLE
add categorytreebehavior to the facets query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `categoryTreeBehavior` to the `facetsV2` query.
+
 ## [0.81.0] - 2021-07-08
 
 ### Added

--- a/react/queries/facetsV2.gql
+++ b/react/queries/facetsV2.gql
@@ -4,6 +4,7 @@ query facetsV2(
   $selectedFacets: [SelectedFacetInput]
   $hideUnavailableItems: Boolean = false
   $behavior: String = "Static"
+  $categoryTreeBehavior: CategoryTreeBehavior = default
   $fuzzy: String
   $operator: Operator
   $searchState: String
@@ -17,6 +18,7 @@ query facetsV2(
     selectedFacets: $selectedFacets
     hideUnavailableItems: $hideUnavailableItems
     behavior: $behavior
+    categoryTreeBehavior: $categoryTreeBehavior
     fuzzy: $fuzzy
     operator: $operator
     searchState: $searchState


### PR DESCRIPTION
#### What is the purpose of this pull request?

⚠️ Do not deploy this before bumping the [search-graphql version](https://github.com/vtex-apps/search-graphql/pull/106) in all resolvers.

Add the `categoryTreeBehavior` to the `facetsV2` query. We will use this field to determine if the back end should return the category tree


#### How should this be manually tested?

[workspace](https://categorytreebehavior--storecomponents.myvtex.com/apparel---accessories/)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
