### PR TITLE
Add sampling to facetsv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `sampling` to `FacetsV2` query.
+
 ## [0.82.0] - 2021-07-14
 
 ### Added

--- a/react/queries/facetsV2.gql
+++ b/react/queries/facetsV2.gql
@@ -24,6 +24,7 @@ query facetsV2(
     searchState: $searchState
     initialAttributes: $initialAttributes
   ) @context(provider: "vtex.search-graphql") {
+    sampling
     breadcrumb {
       name
       href


### PR DESCRIPTION
#### What is the purpose of this pull request?

Depends on 
https://github.com/vtex-apps/search-resolver/pull/227
https://github.com/vtex-apps/search-graphql/pull/110

Now we have a feature to improve search performance that only takes a sampling of the results to get a faster facet query response. 
With this feature enabled for a store, if there is a query that has more results than the limit set by the store, we will only return a sample of that result. 
In these scenarios, it's possible that the amount of products for a facet is returned with a lower value than the actual amount of products for that facet. To avoid an inconsistency in what is displayed to the user, it's necessary for the component to know when only a sample of the data was taken and, in this case, we should not display the amount of products for the facet in the filter navigator.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta--carrefourbr.myvtex.com/admin/graphql-ide)
```
query {
  facets(
    hideUnavailableItems: false,
    behavior: "dynamic",
    query: "eletrodomesticos",
    map: "c",
    from: 0,
    to: 10,
    selectedFacets: [
        {
            key: "c",
            value: "eletrodomesticos"
        }
    ],
    categoryTreeBehavior: default
  ) {
    sampling
    facets{
      name
    }
  }
}
```

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
