### PR TITLE
Add priceDefinition structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Added
+- `priceDefinition` to the `updateItems` mutation
+- `priceDefinition` to the `addToCart` mutation
+- `priceDefinition` to the `orderForm` query
+
 ## [0.84.0] - 2021-08-09
 
 ### Added

--- a/react/mutations/addToCart.gql
+++ b/react/mutations/addToCart.gql
@@ -68,6 +68,14 @@ mutation addItem($orderFormId: String, $items: [OrderFormItemInput], $utmParams:
         }
         parentPrice
       }
+      priceDefinition {
+        calculatedSellingPrice
+        total
+        sellingPrices {
+          quantity
+          value
+        }
+      }
     }
     shippingData {
       address {

--- a/react/mutations/updateItems.gql
+++ b/react/mutations/updateItems.gql
@@ -68,6 +68,14 @@ mutation updateItems($orderFormId: String, $items: [OrderFormItemInput]) {
         }
         parentPrice
       }
+      priceDefinition {
+        calculatedSellingPrice
+        total
+        sellingPrices {
+          quantity
+          value
+        }
+      }
     }
     shippingData {
       address {

--- a/react/queries/orderForm.gql
+++ b/react/queries/orderForm.gql
@@ -102,6 +102,14 @@ query orderForm {
         parentPrice
       }
       seller
+      priceDefinition {
+        calculatedSellingPrice
+        total
+        sellingPrices {
+          quantity
+          value
+        }
+      }
     }
     shippingData {
       address {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add checkout API priceDefinition structure in queries and mutations related to orderForm.
This PR should be merged only after this another one: https://github.com/vtex-apps/store-graphql/pull/557

#### What problem is this solving?

Add these fields solve the presentation of item total when related to the rounding error problem

#### How should this be manually tested?

[Workspace](https://pricedefinition--vtexproject.myvtex.com/_v/private/vtex.store-resources@0.84.0/graphiql/v1?query=query%20%7B%0A%20%20searchOrderForm%20(%0A%20%20%20%20orderFormId%3A%2278f1aa981882432993c6877bbaa7fdd2%22%0A%20%20)%20%7B%0A%20%20%20%20items%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20sellingPrice%0A%20%20%20%20%20%20price%0A%20%20%20%20%20%20quantity%0A%20%20%20%20%20%20priceDefinition%20%7B%0A%20%20%20%20%20%20%20%20calculatedSellingPrice%0A%20%20%20%20%20%20%20%20sellingPrices%20%7B%0A%20%20%20%20%20%20%20%20%20%20quantity%0A%20%20%20%20%20%20%20%20%20%20value%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20total%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/3091668/130149557-216dc9cb-33ef-486d-bf2c-3adafc99de86.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
