### PR TITLE
add spot price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Add `spotPrice` to the `itemsWithSimulation` query.
+
 ## [0.85.0] - 2021-09-01
 
 ## Added

--- a/react/queries/itemsWithSimulation.gql
+++ b/react/queries/itemsWithSimulation.gql
@@ -14,6 +14,7 @@ query itemsWithSimulation($items: [ItemInput]) {
           TotalValuePlusInterestRate
           NumberOfInstallments
       	}
+        spotPrice
       }
     }
   }


### PR DESCRIPTION
#### What problem is this solving?

Add the `sportPrice` field to the `itemsWithSimulation` query.

#### How to test it?

[Workspace](https://hiago--carrefourbr.myvtex.com/)

```
curl --request POST \
  --url 'https://hiago--carrefourbr.myvtex.com/_v/private/graphql/v1?sc=1' \
  --header 'Content-Type: application/json' \
  --data '{"query":"query itemsWithSimulation($items: [ItemInput]) {\n  itemsWithSimulation(items: $items)@context(provider: \"vtex.store-graphql\") {\n    itemId\n    sellers {\n      commertialOffer {\n        spotPrice\n      }\n    }\n  }\n}","variables":{"items":[{"itemId":"4209049","sellers":[{"sellerId":"1"}]}]},"operationName":"itemsWithSimulation"}'
```

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.

#### Depends on

https://github.com/vtex-apps/store-graphql/pull/567