### PR TITLE
add orderby to the productSuggestions query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `orderBy` to the `productSuggestions` query.
+
 ## [0.85.0] - 2021-09-01
 
-## Added
+### Added
 - `priceDefinition` to the `updateItems` mutation
 - `priceDefinition` to the `addToCart` mutation
 - `priceDefinition` to the `orderForm` query

--- a/react/queries/productSuggestions.gql
+++ b/react/queries/productSuggestions.gql
@@ -11,6 +11,7 @@ query productSuggestions(
   $productOriginVtex: Boolean = false
   $simulationBehavior: SimulationBehavior = default
   $hideUnavailableItems: Boolean = false
+  $orderBy: String
 ) {
   productSuggestions(
     fullText: $fullText
@@ -19,6 +20,7 @@ query productSuggestions(
     productOriginVtex: $productOriginVtex
     simulationBehavior: $simulationBehavior
     hideUnavailableItems: $hideUnavailableItems
+    orderBy: $orderBy
   ) @context(provider: "vtex.search-graphql") {
     count
     misspelled


### PR DESCRIPTION
#### What problem is this solving?

Add orderby to the productSuggestions query
https://vtex-dev.atlassian.net/browse/PER-2236

#### How should this be manually tested?

[Workspace](https://hiago--eriksbikeshop.myvtex.com/)

#### Depends on
- https://github.com/vtex-apps/search-graphql/pull/115
