### PR TITLE
Add count to productSuggestions query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `count` to `productSuggestions` query.
+
 ## [0.86.0] - 2022-02-14
 
 ### Added

--- a/react/queries/productSuggestions.gql
+++ b/react/queries/productSuggestions.gql
@@ -12,6 +12,7 @@ query productSuggestions(
   $simulationBehavior: SimulationBehavior = default
   $hideUnavailableItems: Boolean = false
   $orderBy: String
+  $count: Int
 ) {
   productSuggestions(
     fullText: $fullText
@@ -21,6 +22,7 @@ query productSuggestions(
     simulationBehavior: $simulationBehavior
     hideUnavailableItems: $hideUnavailableItems
     orderBy: $orderBy
+    count: $count
   ) @context(provider: "vtex.search-graphql") {
     count
     misspelled


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add count to productSuggestions query, allowing the store to display more than 5 product suggestions.

#### What problem is this solving?
Currently, this manipulation of how many products to display is done on the client. The query always returns 5 and if the maximum is less than 5, a slice is made. However, if the store wants to display more than 5 suggestions, this doesn't work.

#### How should this be manually tested?

- [Workspace](https://thalyta--ametllerorigen.myvtex.com/)
- Autocomplete should show 12 product suggestions

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
