### PR TITLE
Add shippingOptions to products query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `shippingOptions` to `products` query.
+
 ## [0.89.0] - 2023-03-16
 
 ## [0.88.0] - 2022-07-20

--- a/react/QueryProductsTypes.tsx
+++ b/react/QueryProductsTypes.tsx
@@ -35,6 +35,7 @@ export type Variables = {
   hideUnavailableItems?: boolean
   skusFilter?: ItemsFilter
   installmentCriteria?: InstallmentsCriteria
+  shippingOptions?: string[]
 }
 
 // We need to fake usage of some JS from the other modules so they

--- a/react/queries/products.gql
+++ b/react/queries/products.gql
@@ -8,6 +8,7 @@ query Products(
   $category: String
   $collection: String
   $specificationFilters: [String]
+  $shippingOptions: [String]
   $orderBy: String
   $from: Int
   $to: Int
@@ -19,6 +20,7 @@ query Products(
     category: $category
     collection: $collection
     specificationFilters: $specificationFilters
+    shippingOptions: $shippingOptions
     orderBy: $orderBy
     from: $from
     to: $to


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add shippingOptions variable to `products` query
<!--- Describe your changes in detail. -->
Depends on https://github.com/vtex-apps/search-graphql/pull/122

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://shippingoptions--biggy.myvtex.com/?__bindingAddress=biggy.myvtex.com/)

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
