### PR TITLE
Add `anonymousId` query argument for A/B testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Created query parameter `anonymousId` for `sponsoredProducts` used on A/B testing.
+
 ## [0.94.0] - 2023-11-07
 
 ### Added

--- a/react/queries/sponsoredProducts.gql
+++ b/react/queries/sponsoredProducts.gql
@@ -20,6 +20,7 @@ query sponsoredProducts(
   $searchState: String
   $excludedPaymentSystems: [String]
   $includedPaymentSystems: [String]
+  $anonymousId: String
 ) {
   sponsoredProducts(
     fullText: $fullText
@@ -33,6 +34,7 @@ query sponsoredProducts(
     fuzzy: $fuzzy
     operator: $operator
     searchState: $searchState
+    anonymousId: $anonymousId
   ) @context(provider: "vtex.search-graphql") {
       ...ProductFragment
       advertisement {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Allow A/B testing via Osiris.

#### What problem is this solving?

We need to include the argument `anonymousId` on `sponsoredProducts` query.

#### How should this be manually tested?

The following query including `anonymousId` should work:

```graphql
{
  sponsoredProducts(fullText: "camisa", anonymousId:"a") {
    brand
  }
}
```

[Test it here](https://orem--biggy.myvtex.com/_v/private/vtex.store-resources@0.94.0/graphiql/v1?query=%7B%0A%20%20sponsoredProducts(fullText%3A%20%22camisa%22%2C%20anonymousId%3A%22a%22)%20%7B%0A%20%20%20%20brand%0A%20%20%7D%0A%7D).

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
