### PR TITLE
feat: add searchState param to more queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Added `searchState` prop to `searchSuggestions`, `products`, `productRecommendations`, `topSearches` and `autocompleteSearchSuggestions` queries to receive general info from front-end.
 
 ## [0.96.0] - 2024-03-07
 

--- a/react/queries/autocompleteSearchSuggestions.gql
+++ b/react/queries/autocompleteSearchSuggestions.gql
@@ -1,5 +1,5 @@
-query autocompleteSearchSuggestions($fullText: String!) {
-  autocompleteSearchSuggestions(fullText: $fullText)
+query autocompleteSearchSuggestions($fullText: String!, $searchState: String) {
+  autocompleteSearchSuggestions(fullText: $fullText, searchState: $searchState)
     @context(provider: "vtex.search-graphql") {
     searches {
       term

--- a/react/queries/productRecommendations.gql
+++ b/react/queries/productRecommendations.gql
@@ -7,9 +7,13 @@
 query ProductRecommendations(
   $identifier: ProductUniqueIdentifier
   $type: CrossSelingInputEnum
+  $searchState: String
 ) {
-  productRecommendations(identifier: $identifier, type: $type)
-    @context(provider: "vtex.search-graphql") {
+  productRecommendations(
+    identifier: $identifier
+    type: $type
+    searchState: $searchState
+  ) @context(provider: "vtex.search-graphql") {
     ...ProductFragment
     items {
       ...ItemFragment

--- a/react/queries/products.gql
+++ b/react/queries/products.gql
@@ -16,6 +16,7 @@ query Products(
   $skusFilter: ItemsFilter = ALL_AVAILABLE
   $installmentCriteria: InstallmentsCriteria = MAX_WITHOUT_INTEREST
   $variant: String
+  $searchState: String
 ) {
   products(
     category: $category
@@ -27,6 +28,7 @@ query Products(
     to: $to
     hideUnavailableItems: $hideUnavailableItems
     variant: $variant
+    searchState: $searchState
   ) @context(provider: "vtex.search-graphql") {
     ...ProductFragment
     items(filter: $skusFilter) {

--- a/react/queries/searchSuggestions.gql
+++ b/react/queries/searchSuggestions.gql
@@ -1,5 +1,5 @@
-query searchSuggestions($fullText: String!) {
-  searchSuggestions(fullText: $fullText)
+query searchSuggestions($fullText: String!, $searchState: String) {
+  searchSuggestions(fullText: $fullText, searchState: $searchState)
     @context(provider: "vtex.search-graphql") {
     searches {
       term

--- a/react/queries/topSearches.gql
+++ b/react/queries/topSearches.gql
@@ -1,5 +1,6 @@
-query topSearches {
-  topSearches @context(provider: "vtex.search-graphql") {
+query topSearches($searchState: String) {
+  topSearches(searchState: $searchState)
+    @context(provider: "vtex.search-graphql") {
     searches {
       term
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To be able to use the `searchState` param in more queries. This enables us to send user data into the search-resolver app easily from the front-end. Added to the following queries in this PR:
- `searchSuggestions`
- `products`
-  `productRecommendations`
- `topSearches`
- `autocompleteSearchSuggestions`

#### What problem is this solving?

Currently, there is no way to get data from the front-end regarding the user's session into the search resolver directly through these queries. Having this feature to get data this way would help in analytics and to provide better and customized results to the user.

#### How should this be manually tested?

[Workspace](https://usercookie--worldwidegolf.myvtex.com/)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
