### PR TITLE
Feature: add advertisement options to product suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `advertisementOptions` to `productSuggestions`.
+
 ## [0.98.0] - 2024-08-01
 
 ### Added

--- a/react/queries/productSuggestions.gql
+++ b/react/queries/productSuggestions.gql
@@ -15,6 +15,7 @@ query productSuggestions(
   $count: Int
   $shippingOptions: [String]
   $variant: String
+  $advertisementOptions: AdvertisementOptions
 ) {
   productSuggestions(
     fullText: $fullText
@@ -27,6 +28,7 @@ query productSuggestions(
     count: $count
     shippingOptions: $shippingOptions
     variant: $variant
+    advertisementOptions: $advertisementOptions
   ) @context(provider: "vtex.search-graphql") {
     count
     misspelled


### PR DESCRIPTION
#### What is the purpose of this pull request?

Passes advertisement options to product suggestions query so that we can add sponsored products in the autocomplete bar.

#### How should this be manually tested?

https://adsautocomplete--sjdigital.myvtex.com/

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
