### PR TITLE
Adding the selectedProperties to products.gql

### DIFF
--- a/react/queries/products.gql
+++ b/react/queries/products.gql
@@ -45,6 +45,10 @@ query Products(
         }
       }
     }
+    selectedProperties {
+      key
+      value
+    }
     rule {
       id
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the `selectedProperties` to products.gql

#### What problem is this solving?

For stores that do the IS configuration to SKU specifications to display individual products in search results, a query string is added to the product link to direct it to the PDP correctly.

For the correct creation of the link with the query string, the product context must have the selectedProperties field https://github.com/vtex-apps/product-summary-context/blob/2db0baacbb46d5abca53999aac0a348c26916c09/react/ProductSummaryContext.tsx#L143

The problem is that the list-context.product-list context uses the products query from vtex.store-resources which does not have this field. https://github.com/vtex-apps/store-resources/blob/master/react/queries/products.gql

The PDP context already uses the productSearchV3 query which has the selectedProperties https://github.com/vtex-apps/store-resources/blob/master/react/queries/productSearchV3.gql

As in search-graphql this information is present in the products query, I just added it to products.gql.

#### How should this be manually tested?

Activate the configuration in the IS, and see that in the PLP, the product link has the query string `property__${key}`, but the same product on the shelf this query string is not present.

#### Screenshots or example usage

Search settings:

<img width="1207" alt="image" src="https://github.com/user-attachments/assets/28849b71-4299-447a-8fa6-28b80c12cd99" />

Workspace without the fix:
https://nofix--uniandes.myvtex.com/
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/2fbff496-e47f-4632-bdde-810c44eedfff" />

Workspace with the fix:
https://pruebavtex--uniandes.myvtex.com/
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/26c291e1-03e5-4035-a738-46b247640fa8" />


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
