### PR TITLE
feat: add searchId to productSuggestions query response

### DIFF
--- a/react/queries/productSuggestions.gql
+++ b/react/queries/productSuggestions.gql
@@ -55,5 +55,6 @@ query productSuggestions(
         id
       }
     }
+    searchId
   }
 }


### PR DESCRIPTION
This pull request adds a small enhancement to the `query productSuggestions` GraphQL query. The change introduces the `searchId` field to the query response, allowing clients to access the unique identifier associated with a product search.