### PR TITLE
Feat/tis 302

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add `origin` parameter to `productSearchV3` and `productSuggestions` queries
+
 ## [0.104.0] - 2025-09-02
 
 ### Added
@@ -216,7 +220,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.67.0] - 2020-07-23
 ### Added
-- `PaymentSystemName` to `Installments of `Product` query.
+- `PaymentSystemName` to `Installments of`Product` query.
 
 ## [0.66.0] - 2020-07-22
 ### Added

--- a/react/queries/productSearchV3.gql
+++ b/react/queries/productSearchV3.gql
@@ -24,6 +24,7 @@ query productSearchV3(
   $variant: String
   $showSponsored: Boolean
   $advertisementOptions: AdvertisementOptions
+  $origin: String
 ) {
   productSearch(
     query: $query
@@ -41,6 +42,7 @@ query productSearchV3(
     variant: $variant
     showSponsored: $showSponsored
     advertisementOptions: $advertisementOptions
+    origin: $origin
   ) @context(provider: "vtex.search-graphql") {
     products {
       ...ProductFragment

--- a/react/queries/productSuggestions.gql
+++ b/react/queries/productSuggestions.gql
@@ -8,6 +8,7 @@ query productSuggestions(
   $fullText: String!
   $facetKey: String
   $facetValue: String
+  $origin: String
   $productOriginVtex: Boolean = false
   $simulationBehavior: SimulationBehavior = default
   $hideUnavailableItems: Boolean = false
@@ -21,6 +22,7 @@ query productSuggestions(
     fullText: $fullText
     facetKey: $facetKey
     facetValue: $facetValue
+    origin: $origin
     productOriginVtex: $productOriginVtex
     simulationBehavior: $simulationBehavior
     hideUnavailableItems: $hideUnavailableItems

--- a/react/queries/productSuggestions.gql
+++ b/react/queries/productSuggestions.gql
@@ -55,5 +55,6 @@ query productSuggestions(
         id
       }
     }
+    searchId
   }
 }


### PR DESCRIPTION
This pull request updates the GraphQL queries for product search and suggestions to support an additional `origin` parameter and exposes a new `searchId` field in the product suggestions response. These changes enable more flexible querying and tracking of search requests.

**GraphQL query enhancements:**

* Added an optional `origin` parameter to the `productSearchV3` query definition and passed it to the server, allowing clients to specify the source of the search request. [[1]](diffhunk://#diff-8a40d928c4aa83928add5b55bbe2621b0d679b6cb6cab0ea7bd19d16d23ddfe7R27) [[2]](diffhunk://#diff-8a40d928c4aa83928add5b55bbe2621b0d679b6cb6cab0ea7bd19d16d23ddfe7R45)
* Added an optional `origin` parameter to the `productSuggestions` query definition and included it in the server request, enabling source tracking for product suggestions. [[1]](diffhunk://#diff-9c5fa35f47378068fdf019af8b0ecfb352daf50b5fbb4c21f341aeb25fa6a7e6R11) [[2]](diffhunk://#diff-9c5fa35f47378068fdf019af8b0ecfb352daf50b5fbb4c21f341aeb25fa6a7e6R25)

**Response data improvements:**

* Exposed the `searchId` field in the `productSuggestions` query response, allowing clients to uniquely identify search sessions.