### PR TITLE
feat(TIS-388): add specification field to productSearchV3 query response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add `specification` on `productSearchV3` and `productSuggestions` queries
+
 ## [0.104.2] - 2025-10-06
 
 ### Added

--- a/react/queries/productSearchV3.gql
+++ b/react/queries/productSearchV3.gql
@@ -81,6 +81,7 @@ query productSearchV3(
         pickupId
         pickupName
       }
+      specification
     }
     recordsFiltered
     correction {

--- a/react/queries/productSuggestions.gql
+++ b/react/queries/productSuggestions.gql
@@ -56,6 +56,7 @@ query productSuggestions(
       rule {
         id
       }
+      specification
     }
     searchId
   }


### PR DESCRIPTION
This pull request introduces a minor update to the `productSearchV3` GraphQL query. The change adds the `specification` field to the returned data, allowing clients to access product specifications directly from the query.

* Added the `specification` field to the `productSearchV3` query response.